### PR TITLE
refactor(java): Streamline ClassResolver responsibilities

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -39,6 +39,7 @@ import org.apache.fury.config.Language;
 import org.apache.fury.config.LongEncoding;
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.memory.MemoryUtils;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.resolver.ClassInfo;
 import org.apache.fury.resolver.ClassInfoHolder;
 import org.apache.fury.resolver.ClassResolver;
@@ -514,35 +515,35 @@ public final class Fury implements BaseFury {
   /** Write not null data to buffer. */
   private void writeData(MemoryBuffer buffer, ClassInfo classInfo, Object obj) {
     switch (classInfo.getClassId()) {
-      case ClassResolver.BOOLEAN_CLASS_ID:
+      case BuiltinClassId.BOOLEAN_CLASS_ID:
         buffer.writeBoolean((Boolean) obj);
         break;
-      case ClassResolver.BYTE_CLASS_ID:
+      case BuiltinClassId.BYTE_CLASS_ID:
         buffer.writeByte((Byte) obj);
         break;
-      case ClassResolver.CHAR_CLASS_ID:
+      case BuiltinClassId.CHAR_CLASS_ID:
         buffer.writeChar((Character) obj);
         break;
-      case ClassResolver.SHORT_CLASS_ID:
+      case BuiltinClassId.SHORT_CLASS_ID:
         buffer.writeShort((Short) obj);
         break;
-      case ClassResolver.INTEGER_CLASS_ID:
+      case BuiltinClassId.INTEGER_CLASS_ID:
         if (compressInt) {
           buffer.writeVarInt((Integer) obj);
         } else {
           buffer.writeInt((Integer) obj);
         }
         break;
-      case ClassResolver.FLOAT_CLASS_ID:
+      case BuiltinClassId.FLOAT_CLASS_ID:
         buffer.writeFloat((Float) obj);
         break;
-      case ClassResolver.LONG_CLASS_ID:
+      case BuiltinClassId.LONG_CLASS_ID:
         LongSerializer.writeLong(buffer, (Long) obj, longEncoding);
         break;
-      case ClassResolver.DOUBLE_CLASS_ID:
+      case BuiltinClassId.DOUBLE_CLASS_ID:
         buffer.writeDouble((Double) obj);
         break;
-      case ClassResolver.STRING_CLASS_ID:
+      case BuiltinClassId.STRING_CLASS_ID:
         stringSerializer.writeJavaString(buffer, (String) obj);
         break;
         // TODO(add fastpath for other types)
@@ -870,27 +871,27 @@ public final class Fury implements BaseFury {
 
   private Object readDataInternal(MemoryBuffer buffer, ClassInfo classInfo) {
     switch (classInfo.getClassId()) {
-      case ClassResolver.BOOLEAN_CLASS_ID:
+      case BuiltinClassId.BOOLEAN_CLASS_ID:
         return buffer.readBoolean();
-      case ClassResolver.BYTE_CLASS_ID:
+      case BuiltinClassId.BYTE_CLASS_ID:
         return buffer.readByte();
-      case ClassResolver.CHAR_CLASS_ID:
+      case BuiltinClassId.CHAR_CLASS_ID:
         return buffer.readChar();
-      case ClassResolver.SHORT_CLASS_ID:
+      case BuiltinClassId.SHORT_CLASS_ID:
         return buffer.readShort();
-      case ClassResolver.INTEGER_CLASS_ID:
+      case BuiltinClassId.INTEGER_CLASS_ID:
         if (compressInt) {
           return buffer.readVarInt();
         } else {
           return buffer.readInt();
         }
-      case ClassResolver.FLOAT_CLASS_ID:
+      case BuiltinClassId.FLOAT_CLASS_ID:
         return buffer.readFloat();
-      case ClassResolver.LONG_CLASS_ID:
+      case BuiltinClassId.LONG_CLASS_ID:
         return LongSerializer.readLong(buffer, longEncoding);
-      case ClassResolver.DOUBLE_CLASS_ID:
+      case BuiltinClassId.DOUBLE_CLASS_ID:
         return buffer.readDouble();
-      case ClassResolver.STRING_CLASS_ID:
+      case BuiltinClassId.STRING_CLASS_ID:
         return stringSerializer.readJavaString(buffer);
         // TODO(add fastpath for other types)
       default:

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
@@ -65,8 +65,8 @@ import org.apache.fury.codegen.Expression.While;
 import org.apache.fury.codegen.ExpressionOptimizer;
 import org.apache.fury.codegen.ExpressionUtils;
 import org.apache.fury.collection.Tuple2;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.resolver.ClassInfo;
-import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.resolver.FieldResolver;
 import org.apache.fury.resolver.FieldResolver.CollectionFieldInfo;
 import org.apache.fury.resolver.FieldResolver.FieldInfo;
@@ -879,7 +879,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
   protected Expression writeFinalClassInfo(Expression buffer, Class<?> cls) {
     Preconditions.checkArgument(ReflectionUtils.isMonomorphic(cls));
     ClassInfo classInfo = visitFury(f -> f.getClassResolver().getClassInfo(cls, false));
-    if (classInfo != null && classInfo.getClassId() != ClassResolver.NO_CLASS_ID) {
+    if (classInfo != null && classInfo.getClassId() != BuiltinClassId.NO_CLASS_ID) {
       return fury.getClassResolver().writeClassExpr(buffer, classInfo.getClassId());
     }
     Expression classInfoExpr = getFinalClassInfo(cls);
@@ -889,7 +889,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
   protected Expression skipFinalClassInfo(Class<?> cls, Expression buffer) {
     Preconditions.checkArgument(ReflectionUtils.isMonomorphic(cls));
     ClassInfo classInfo = visitFury(f -> f.getClassResolver().getClassInfo(cls, false));
-    if (classInfo != null && classInfo.getClassId() != ClassResolver.NO_CLASS_ID) {
+    if (classInfo != null && classInfo.getClassId() != BuiltinClassId.NO_CLASS_ID) {
       return fury.getClassResolver().skipRegisteredClassExpr(buffer);
     }
     // read `ClassInfo` is not used, set `inlineReadClassInfo` false,

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassIdAllocator.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassIdAllocator.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.resolver;
+
+import java.util.function.Function;
+import org.apache.fury.util.Preconditions;
+
+/** Responsible for allocating ClassId and maintaining built-in ClassId. */
+public class ClassIdAllocator {
+  public static class BuiltinClassId {
+    // preserve 0 as flag for class id not set in ClassInfo`
+    public static final short NO_CLASS_ID = (short) 0;
+    public static final short LAMBDA_STUB_ID = 1;
+    public static final short JDK_PROXY_STUB_ID = 2;
+    public static final short REPLACE_STUB_ID = 3;
+    // Note: following pre-defined class id should be continuous, since they may be used based
+    // range.
+    public static final short PRIMITIVE_VOID_CLASS_ID = (short) (REPLACE_STUB_ID + 1);
+    public static final short PRIMITIVE_BOOLEAN_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 1);
+    public static final short PRIMITIVE_BYTE_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 2);
+    public static final short PRIMITIVE_CHAR_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 3);
+    public static final short PRIMITIVE_SHORT_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 4);
+    public static final short PRIMITIVE_INT_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 5);
+    public static final short PRIMITIVE_FLOAT_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 6);
+    public static final short PRIMITIVE_LONG_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 7);
+    public static final short PRIMITIVE_DOUBLE_CLASS_ID = (short) (PRIMITIVE_VOID_CLASS_ID + 8);
+    public static final short VOID_CLASS_ID = (short) (PRIMITIVE_DOUBLE_CLASS_ID + 1);
+    public static final short BOOLEAN_CLASS_ID = (short) (VOID_CLASS_ID + 1);
+    public static final short BYTE_CLASS_ID = (short) (VOID_CLASS_ID + 2);
+    public static final short CHAR_CLASS_ID = (short) (VOID_CLASS_ID + 3);
+    public static final short SHORT_CLASS_ID = (short) (VOID_CLASS_ID + 4);
+    public static final short INTEGER_CLASS_ID = (short) (VOID_CLASS_ID + 5);
+    public static final short FLOAT_CLASS_ID = (short) (VOID_CLASS_ID + 6);
+    public static final short LONG_CLASS_ID = (short) (VOID_CLASS_ID + 7);
+    public static final short DOUBLE_CLASS_ID = (short) (VOID_CLASS_ID + 8);
+    public static final short STRING_CLASS_ID = (short) (VOID_CLASS_ID + 9);
+    public static final short PRIMITIVE_BOOLEAN_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 1);
+    public static final short PRIMITIVE_BYTE_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 2);
+    public static final short PRIMITIVE_CHAR_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 3);
+    public static final short PRIMITIVE_SHORT_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 4);
+    public static final short PRIMITIVE_INT_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 5);
+    public static final short PRIMITIVE_FLOAT_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 6);
+    public static final short PRIMITIVE_LONG_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 7);
+    public static final short PRIMITIVE_DOUBLE_ARRAY_CLASS_ID = (short) (STRING_CLASS_ID + 8);
+    public static final short STRING_ARRAY_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 1);
+    public static final short OBJECT_ARRAY_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 2);
+    public static final short ARRAYLIST_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 3);
+    public static final short HASHMAP_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 4);
+    public static final short HASHSET_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 5);
+    public static final short CLASS_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 6);
+    public static final short EMPTY_OBJECT_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 7);
+  }
+
+  // class id of last default registered class.
+  private short innerEndClassId;
+  // Here we set it to 1 because `NO_CLASS_ID` is 0 to avoid calculating it again in
+  // `register(Class<?> cls)`.
+  private short classIdGenerator = 1;
+
+  private final Function<Class<?>, Boolean> classRegisteredFactory;
+
+  private final Function<Short, Boolean> classIdRegisteredFactory;
+
+  public ClassIdAllocator(
+      Function<Class<?>, Boolean> classRegisteredFactory,
+      Function<Short, Boolean> classIdRegisteredFactory) {
+    Preconditions.checkNotNull(classRegisteredFactory);
+    Preconditions.checkNotNull(classIdRegisteredFactory);
+    this.classRegisteredFactory = classRegisteredFactory;
+    this.classIdRegisteredFactory = classIdRegisteredFactory;
+  }
+
+  public short allocateClassId(Class<?> cls) {
+    if (!classRegisteredFactory.apply(cls)) {
+      while (classIdRegisteredFactory.apply(classIdGenerator)) {
+        classIdGenerator++;
+      }
+    }
+    return classIdGenerator;
+  }
+
+  public void notifyRegistrationEnd() {
+    classIdGenerator++;
+  }
+
+  public void markInternalRegistrationEnd() {
+    innerEndClassId = classIdGenerator;
+  }
+
+  public boolean isInnerClass(Short classId) {
+    return classId != null && classId != BuiltinClassId.NO_CLASS_ID && classId < innerEndClassId;
+  }
+
+  public boolean isPrimitive(short classId) {
+    return classId >= BuiltinClassId.PRIMITIVE_VOID_CLASS_ID
+        && classId <= BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID;
+  }
+}

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassInfo.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassInfo.java
@@ -58,7 +58,7 @@ public class ClassInfo {
     this.typeTagBytes = typeTagBytes;
     this.serializer = serializer;
     this.classId = classId;
-    if (cls != null && classId == ClassResolver.NO_CLASS_ID) {
+    if (cls != null && classId == ClassIdAllocator.BuiltinClassId.NO_CLASS_ID) {
       Preconditions.checkArgument(classNameBytes != null);
     }
   }
@@ -78,7 +78,8 @@ public class ClassInfo {
       this.fullClassNameBytes = null;
     }
     if (cls != null
-        && (classId == ClassResolver.NO_CLASS_ID || classId == ClassResolver.REPLACE_STUB_ID)) {
+        && (classId == ClassIdAllocator.BuiltinClassId.NO_CLASS_ID
+            || classId == ClassIdAllocator.BuiltinClassId.REPLACE_STUB_ID)) {
       // REPLACE_STUB_ID for write replace class in `ClassSerializer`.
       String packageName = ReflectionUtils.getPackage(cls);
       this.packageNameBytes = enumStringResolver.getOrCreateEnumStringBytes(packageName);
@@ -100,10 +101,10 @@ public class ClassInfo {
       boolean isProxy = ReflectionUtils.isJdkProxy(cls);
       this.isDynamicGeneratedClass = isLambda || isProxy;
       if (isLambda) {
-        this.classId = ClassResolver.LAMBDA_STUB_ID;
+        this.classId = ClassIdAllocator.BuiltinClassId.LAMBDA_STUB_ID;
       }
       if (isProxy) {
-        this.classId = ClassResolver.JDK_PROXY_STUB_ID;
+        this.classId = ClassIdAllocator.BuiltinClassId.JDK_PROXY_STUB_ID;
       }
     } else {
       this.isDynamicGeneratedClass = false;

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
@@ -19,8 +19,7 @@
 
 package org.apache.fury.resolver;
 
-import static org.apache.fury.resolver.ClassResolver.NO_CLASS_ID;
-import static org.apache.fury.resolver.ClassResolver.PRIMITIVE_LONG_CLASS_ID;
+import static org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import static org.apache.fury.resolver.FieldResolver.FieldInfoEncodingType.EMBED_TYPES_4;
 import static org.apache.fury.resolver.FieldResolver.FieldInfoEncodingType.EMBED_TYPES_9;
 import static org.apache.fury.resolver.FieldResolver.FieldInfoEncodingType.EMBED_TYPES_HASH;
@@ -478,9 +477,9 @@ public class FieldResolver {
       }
       ClassInfo classInfo = classResolver.getClassInfo(classId);
       if (classId >= minPrimitiveClassId && classId <= maxPrimitiveClassId) {
-        if (classId == ClassResolver.PRIMITIVE_INT_CLASS_ID) {
+        if (classId == BuiltinClassId.PRIMITIVE_INT_CLASS_ID) {
           intSerializer.read(buffer);
-        } else if (classId == PRIMITIVE_LONG_CLASS_ID) {
+        } else if (classId == BuiltinClassId.PRIMITIVE_LONG_CLASS_ID) {
           longSerializer.read(buffer);
         } else {
           fury.readData(buffer, classInfo);
@@ -739,7 +738,7 @@ public class FieldResolver {
             FieldTypes.OBJECT,
             fieldInfoEncodingType,
             encodedFieldInfo,
-            NO_CLASS_ID);
+            BuiltinClassId.NO_CLASS_ID);
       }
       if (Collection.class.isAssignableFrom(field.getType())) {
         TypeToken<?> elementTypeToken =
@@ -783,7 +782,7 @@ public class FieldResolver {
             FieldTypes.OBJECT,
             fieldInfoEncodingType,
             encodedFieldInfo,
-            NO_CLASS_ID);
+            BuiltinClassId.NO_CLASS_ID);
       }
     }
 
@@ -825,8 +824,8 @@ public class FieldResolver {
 
     public ClassInfo getClassInfo(short classId) {
       ClassInfo classInfo = this.classInfoHolder.classInfo;
-      if (classInfo.classId == NO_CLASS_ID) {
-        Preconditions.checkArgument(classId != NO_CLASS_ID);
+      if (classInfo.classId == BuiltinClassId.NO_CLASS_ID) {
+        Preconditions.checkArgument(classId != BuiltinClassId.NO_CLASS_ID);
         this.classInfoHolder.classInfo = classInfo = classResolver.getClassInfo(classId);
       }
       return classInfo;
@@ -875,7 +874,7 @@ public class FieldResolver {
           fieldType,
           fieldInfoEncodingType,
           encodedFieldInfo,
-          NO_CLASS_ID);
+          BuiltinClassId.NO_CLASS_ID);
       Preconditions.checkArgument(field != STUB_FIELD);
       this.elementTypeToken = elementTypeToken;
       this.elementType = getRawType(elementTypeToken);
@@ -926,7 +925,7 @@ public class FieldResolver {
           fieldType,
           separateTypesHash,
           encodedFieldInfo,
-          NO_CLASS_ID);
+          BuiltinClassId.NO_CLASS_ID);
       Preconditions.checkArgument(field != STUB_FIELD);
       this.keyTypeToken = keyTypeToken;
       this.valueTypeToken = valueTypeToken;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.fury.Fury;
 import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.resolver.ClassInfo;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.resolver.FieldResolver;
@@ -151,7 +152,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
       Object fieldValue;
       fieldValue = fieldAccessor.getObject(targetObject);
       if (ObjectSerializer.writeBasicObjectFieldValueFailed(fury, buffer, fieldValue, classId)) {
-        if (classId == ClassResolver.NO_CLASS_ID) { // SEPARATE_TYPES_HASH
+        if (classId == BuiltinClassId.NO_CLASS_ID) { // SEPARATE_TYPES_HASH
           writeSeparateFieldValue(fieldInfo, buffer, fieldValue);
         } else {
           ClassInfo classInfo = fieldInfo.getClassInfo(classId);
@@ -167,38 +168,38 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     short classId = fieldInfo.getEmbeddedClassId();
     // PRIMITIVE fields, not need for null check.
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         buffer.writeBoolean((Boolean) fieldValue);
         return;
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         buffer.writeByte((Byte) fieldValue);
         return;
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         buffer.writeChar((Character) fieldValue);
         return;
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         buffer.writeShort((Short) fieldValue);
         return;
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           buffer.writeVarInt((Integer) fieldValue);
         } else {
           buffer.writeInt((Integer) fieldValue);
         }
         return;
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         buffer.writeFloat((Float) fieldValue);
         return;
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         fury.writeLong(buffer, (Long) fieldValue);
         return;
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         buffer.writeDouble((Double) fieldValue);
         return;
-      case ClassResolver.STRING_CLASS_ID:
+      case BuiltinClassId.STRING_CLASS_ID:
         fury.writeJavaStringRef(buffer, (String) fieldValue);
         break;
-      case ClassResolver.NO_CLASS_ID: // SEPARATE_TYPES_HASH
+      case BuiltinClassId.NO_CLASS_ID: // SEPARATE_TYPES_HASH
         writeSeparateFieldValue(fieldInfo, buffer, fieldValue);
         break;
       default:
@@ -552,7 +553,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
             fury, buffer, targetObject, fieldAccessor, classId)
         && ObjectSerializer.readBasicObjectFieldValueFailed(
             fury, buffer, targetObject, fieldAccessor, classId)) {
-      if (classId == ClassResolver.NO_CLASS_ID) {
+      if (classId == BuiltinClassId.NO_CLASS_ID) {
         // SEPARATE_TYPES_HASH
         Object fieldValue = fieldResolver.readObjectField(buffer, fieldInfo);
         fieldAccessor.putObject(targetObject, fieldValue);
@@ -568,29 +569,29 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     short classId = fieldInfo.getEmbeddedClassId();
     // PRIMITIVE fields, not need for null check.
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         return buffer.readBoolean();
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         return buffer.readByte();
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         return buffer.readChar();
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         return buffer.readShort();
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           return buffer.readVarInt();
         } else {
           return buffer.readInt();
         }
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         return buffer.readFloat();
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         return fury.readLong(buffer);
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         return buffer.readDouble();
-      case ClassResolver.STRING_CLASS_ID:
+      case BuiltinClassId.STRING_CLASS_ID:
         return fury.readJavaStringRef(buffer);
-      case ClassResolver.NO_CLASS_ID:
+      case BuiltinClassId.NO_CLASS_ID:
         return fieldResolver.readObjectField(buffer, fieldInfo);
       default:
         {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
@@ -36,6 +36,7 @@ import org.apache.fury.collection.Tuple3;
 import org.apache.fury.config.CompatibleMode;
 import org.apache.fury.config.FuryBuilder;
 import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.resolver.ClassInfoHolder;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.resolver.RefResolver;
@@ -216,8 +217,8 @@ public class MetaSharedSerializer<T> extends Serializer<T> {
         assert fieldInfo.classInfo != null;
         short classId = fieldInfo.classId;
         // primitive field won't write null flag.
-        if (classId >= ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID
-            && classId <= ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID) {
+        if (classId >= BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID
+            && classId <= BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID) {
           fields[counter++] = Serializers.readPrimitiveValue(fury, buffer, classId);
         } else {
           Object fieldValue =
@@ -253,32 +254,32 @@ public class MetaSharedSerializer<T> extends Serializer<T> {
   /** Skip primitive primitive field value since it doesn't write null flag. */
   static boolean skipPrimitiveFieldValueFailed(Fury fury, short classId, MemoryBuffer buffer) {
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         buffer.increaseReaderIndex(1);
         return false;
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         buffer.increaseReaderIndex(1);
         return false;
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         buffer.increaseReaderIndex(2);
         return false;
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         buffer.increaseReaderIndex(2);
         return false;
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           buffer.readVarInt();
         } else {
           buffer.increaseReaderIndex(4);
         }
         return false;
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         buffer.increaseReaderIndex(4);
         return false;
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         fury.readLong(buffer);
         return false;
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         buffer.increaseReaderIndex(8);
         return false;
       default:

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
@@ -34,6 +34,7 @@ import org.apache.fury.collection.Tuple2;
 import org.apache.fury.collection.Tuple3;
 import org.apache.fury.exception.FuryException;
 import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.resolver.ClassInfo;
 import org.apache.fury.resolver.ClassInfoHolder;
 import org.apache.fury.resolver.ClassResolver;
@@ -334,8 +335,8 @@ public final class ObjectSerializer<T> extends Serializer<T> {
       FinalTypeField fieldInfo = finalFields[i];
       boolean isFinal = !metaContextShareEnabled || this.isFinal[i];
       short classId = fieldInfo.classId;
-      if (classId >= ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID
-          && classId <= ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID) {
+      if (classId >= BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID
+          && classId <= BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID) {
         fieldValues[counter++] = Serializers.readPrimitiveValue(fury, buffer, classId);
       } else {
         Object fieldValue =
@@ -478,19 +479,19 @@ public final class ObjectSerializer<T> extends Serializer<T> {
       return writePrimitiveFieldValueFailed(fury, buffer, targetObject, fieldOffset, classId);
     }
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         buffer.writeBoolean((Boolean) fieldAccessor.get(targetObject));
         return false;
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         buffer.writeByte((Byte) fieldAccessor.get(targetObject));
         return false;
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         buffer.writeChar((Character) fieldAccessor.get(targetObject));
         return false;
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         buffer.writeShort((Short) fieldAccessor.get(targetObject));
         return false;
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         {
           int fieldValue = (Integer) fieldAccessor.get(targetObject);
           if (fury.compressInt()) {
@@ -500,16 +501,16 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         buffer.writeFloat((Float) fieldAccessor.get(targetObject));
         return false;
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         {
           long fieldValue = (long) fieldAccessor.get(targetObject);
           fury.writeLong(buffer, fieldValue);
           return false;
         }
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         buffer.writeDouble((Double) fieldAccessor.get(targetObject));
         return false;
       default:
@@ -520,19 +521,19 @@ public final class ObjectSerializer<T> extends Serializer<T> {
   static boolean writePrimitiveFieldValueFailed(
       Fury fury, MemoryBuffer buffer, Object targetObject, long fieldOffset, short classId) {
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         buffer.writeBoolean(Platform.getBoolean(targetObject, fieldOffset));
         return false;
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         buffer.writeByte(Platform.getByte(targetObject, fieldOffset));
         return false;
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         buffer.writeChar(Platform.getChar(targetObject, fieldOffset));
         return false;
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         buffer.writeShort(Platform.getShort(targetObject, fieldOffset));
         return false;
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         {
           int fieldValue = Platform.getInt(targetObject, fieldOffset);
           if (fury.compressInt()) {
@@ -542,16 +543,16 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         buffer.writeFloat(Platform.getFloat(targetObject, fieldOffset));
         return false;
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         {
           long fieldValue = Platform.getLong(targetObject, fieldOffset);
           fury.writeLong(buffer, fieldValue);
           return false;
         }
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         buffer.writeDouble(Platform.getDouble(targetObject, fieldOffset));
         return false;
       default:
@@ -571,10 +572,10 @@ public final class ObjectSerializer<T> extends Serializer<T> {
     }
     // add time types serialization here.
     switch (classId) {
-      case ClassResolver.STRING_CLASS_ID: // fastpath for string.
+      case BuiltinClassId.STRING_CLASS_ID: // fastpath for string.
         fury.writeJavaStringRef(buffer, (String) (fieldValue));
         return false;
-      case ClassResolver.BOOLEAN_CLASS_ID:
+      case BuiltinClassId.BOOLEAN_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -584,7 +585,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.BYTE_CLASS_ID:
+      case BuiltinClassId.BYTE_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -594,7 +595,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.CHAR_CLASS_ID:
+      case BuiltinClassId.CHAR_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -604,7 +605,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.SHORT_CLASS_ID:
+      case BuiltinClassId.SHORT_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -614,7 +615,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.INTEGER_CLASS_ID:
+      case BuiltinClassId.INTEGER_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -628,7 +629,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.FLOAT_CLASS_ID:
+      case BuiltinClassId.FLOAT_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -638,7 +639,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.LONG_CLASS_ID:
+      case BuiltinClassId.LONG_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -648,7 +649,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.DOUBLE_CLASS_ID:
+      case BuiltinClassId.DOUBLE_CLASS_ID:
         {
           if (fieldValue == null) {
             buffer.writeByte(Fury.NULL_FLAG);
@@ -680,35 +681,35 @@ public final class ObjectSerializer<T> extends Serializer<T> {
       return readPrimitiveFieldValueFailed(fury, buffer, targetObject, fieldOffset, classId);
     }
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         fieldAccessor.set(targetObject, buffer.readBoolean());
         return false;
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         fieldAccessor.set(targetObject, buffer.readByte());
         return false;
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         fieldAccessor.set(targetObject, buffer.readChar());
         return false;
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         fieldAccessor.set(targetObject, buffer.readShort());
         return false;
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           fieldAccessor.set(targetObject, buffer.readVarInt());
         } else {
           fieldAccessor.set(targetObject, buffer.readInt());
         }
         return false;
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         fieldAccessor.set(targetObject, buffer.readFloat());
         return false;
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         fieldAccessor.set(targetObject, fury.readLong(buffer));
         return false;
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         fieldAccessor.set(targetObject, buffer.readDouble());
         return false;
-      case ClassResolver.STRING_CLASS_ID:
+      case BuiltinClassId.STRING_CLASS_ID:
         fieldAccessor.putObject(targetObject, fury.readJavaStringRef(buffer));
         return false;
       default:
@@ -721,35 +722,35 @@ public final class ObjectSerializer<T> extends Serializer<T> {
   private static boolean readPrimitiveFieldValueFailed(
       Fury fury, MemoryBuffer buffer, Object targetObject, long fieldOffset, short classId) {
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         Platform.putBoolean(targetObject, fieldOffset, buffer.readBoolean());
         return false;
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         Platform.putByte(targetObject, fieldOffset, buffer.readByte());
         return false;
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         Platform.putChar(targetObject, fieldOffset, buffer.readChar());
         return false;
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         Platform.putShort(targetObject, fieldOffset, buffer.readShort());
         return false;
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           Platform.putInt(targetObject, fieldOffset, buffer.readVarInt());
         } else {
           Platform.putInt(targetObject, fieldOffset, buffer.readInt());
         }
         return false;
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         Platform.putFloat(targetObject, fieldOffset, buffer.readFloat());
         return false;
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         Platform.putLong(targetObject, fieldOffset, fury.readLong(buffer));
         return false;
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         Platform.putDouble(targetObject, fieldOffset, buffer.readDouble());
         return false;
-      case ClassResolver.STRING_CLASS_ID:
+      case BuiltinClassId.STRING_CLASS_ID:
         Platform.putObject(targetObject, fieldOffset, fury.readJavaStringRef(buffer));
         return false;
       default:
@@ -770,10 +771,10 @@ public final class ObjectSerializer<T> extends Serializer<T> {
     }
     // add time types serialization here.
     switch (classId) {
-      case ClassResolver.STRING_CLASS_ID: // fastpath for string.
+      case BuiltinClassId.STRING_CLASS_ID: // fastpath for string.
         fieldAccessor.putObject(targetObject, fury.readJavaStringRef(buffer));
         return false;
-      case ClassResolver.BOOLEAN_CLASS_ID:
+      case BuiltinClassId.BOOLEAN_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -782,7 +783,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.BYTE_CLASS_ID:
+      case BuiltinClassId.BYTE_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -791,7 +792,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.CHAR_CLASS_ID:
+      case BuiltinClassId.CHAR_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -800,7 +801,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.SHORT_CLASS_ID:
+      case BuiltinClassId.SHORT_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -809,7 +810,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.INTEGER_CLASS_ID:
+      case BuiltinClassId.INTEGER_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -822,7 +823,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.FLOAT_CLASS_ID:
+      case BuiltinClassId.FLOAT_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -831,7 +832,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.LONG_CLASS_ID:
+      case BuiltinClassId.LONG_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -840,7 +841,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           }
           return false;
         }
-      case ClassResolver.DOUBLE_CLASS_ID:
+      case BuiltinClassId.DOUBLE_CLASS_ID:
         {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
@@ -946,7 +947,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
 
   private static short getRegisteredClassId(Fury fury, Class<?> cls) {
     Short classId = fury.getClassResolver().getRegisteredClassId(cls);
-    return classId == null ? ClassResolver.NO_CLASS_ID : classId;
+    return classId == null ? BuiltinClassId.NO_CLASS_ID : classId;
   }
 
   public static int computeVersionHash(Collection<Descriptor> descriptors) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
@@ -51,6 +51,7 @@ import org.apache.fury.builder.Generated;
 import org.apache.fury.collection.ObjectArray;
 import org.apache.fury.collection.ObjectIntMap;
 import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.resolver.ClassInfo;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.resolver.FieldResolver;
@@ -327,7 +328,7 @@ public class ObjectStreamSerializer extends Serializer {
 
     public SlotsInfo(Fury fury, Class<?> type) {
       this.cls = type;
-      classInfo = fury.getClassResolver().newClassInfo(type, null, ClassResolver.NO_CLASS_ID);
+      classInfo = fury.getClassResolver().newClassInfo(type, null, BuiltinClassId.NO_CLASS_ID);
       ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(type);
       streamClassInfo = STREAM_CLASS_INFO_CACHE.get(type);
       // `putFields/writeFields` will convert to fields value to be written by

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ReplaceResolveSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ReplaceResolveSerializer.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.apache.fury.Fury;
 import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.resolver.ClassInfo;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.resolver.RefResolver;
@@ -216,7 +217,7 @@ public class ReplaceResolveSerializer extends Serializer {
       jdkMethodInfoWriteCache = newJDKMethodInfoCache(type, fury);
       classClassInfoHolderMap.put(type, jdkMethodInfoWriteCache);
       // FIXME new classinfo may miss serializer update in async compilation mode.
-      writeClassInfo = classResolver.newClassInfo(type, this, ClassResolver.NO_CLASS_ID);
+      writeClassInfo = classResolver.newClassInfo(type, this, BuiltinClassId.NO_CLASS_ID);
     } else {
       jdkMethodInfoWriteCache = null;
       writeClassInfo = null;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -44,7 +44,7 @@ import java.util.regex.Pattern;
 import org.apache.fury.Fury;
 import org.apache.fury.collection.Tuple2;
 import org.apache.fury.memory.MemoryBuffer;
-import org.apache.fury.resolver.ClassResolver;
+import org.apache.fury.resolver.ClassIdAllocator.BuiltinClassId;
 import org.apache.fury.type.Type;
 import org.apache.fury.util.GraalvmSupport;
 import org.apache.fury.util.Platform;
@@ -149,25 +149,25 @@ public class Serializers {
 
   public static Object readPrimitiveValue(Fury fury, MemoryBuffer buffer, short classId) {
     switch (classId) {
-      case ClassResolver.PRIMITIVE_BOOLEAN_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BOOLEAN_CLASS_ID:
         return buffer.readBoolean();
-      case ClassResolver.PRIMITIVE_BYTE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_BYTE_CLASS_ID:
         return buffer.readByte();
-      case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_CHAR_CLASS_ID:
         return buffer.readChar();
-      case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_SHORT_CLASS_ID:
         return buffer.readShort();
-      case ClassResolver.PRIMITIVE_INT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           return buffer.readVarInt();
         } else {
           return buffer.readInt();
         }
-      case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_FLOAT_CLASS_ID:
         return buffer.readFloat();
-      case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_LONG_CLASS_ID:
         return fury.readLong(buffer);
-      case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
+      case BuiltinClassId.PRIMITIVE_DOUBLE_CLASS_ID:
         return buffer.readDouble();
       default:
         {

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -44,6 +44,7 @@ import org.apache.fury.config.CompatibleMode;
 import org.apache.fury.config.FuryBuilder;
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.memory.MemoryUtils;
+import org.apache.fury.resolver.ClassIdAllocator;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.serializer.CompatibleSerializer;
 import org.apache.fury.util.LoggerFactory;
@@ -661,7 +662,7 @@ public class ClassDef implements Serializable {
                   : genericType.getTypeParameter1()));
     } else {
       Short classId = classResolver.getRegisteredClassId(rawType);
-      if (classId != null && classId != ClassResolver.NO_CLASS_ID) {
+      if (classId != null && classId != ClassIdAllocator.BuiltinClassId.NO_CLASS_ID) {
         return new RegisteredFieldType(isFinal, classId);
       } else {
         return new ObjectFieldType(isFinal);
@@ -696,7 +697,7 @@ public class ClassDef implements Serializable {
                   : genericType.getTypeParameter1()));
     } else {
       Short classId = classResolver.getRegisteredClassId(genericType.cls);
-      if (classId != null && classId != ClassResolver.NO_CLASS_ID) {
+      if (classId != null && classId != ClassIdAllocator.BuiltinClassId.NO_CLASS_ID) {
         return new RegisteredFieldType(isFinal, classId);
       } else {
         return new ObjectFieldType(isFinal);

--- a/java/fury-core/src/test/java/org/apache/fury/resolver/ClassIdAllocatorTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/resolver/ClassIdAllocatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.resolver;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ClassIdAllocatorTest {
+  @Test
+  public void testInvalidConstructorArguments() {
+    Assert.assertThrows(
+        NullPointerException.class,
+        () -> {
+          new ClassIdAllocator(null, null);
+        });
+  }
+
+  @Test
+  public void testInnerClass() {
+    ClassIdAllocator allocator = new ClassIdAllocator((cls) -> true, (classId) -> true);
+    int innerRegisteredCount = 10;
+    for (int i = 0; i < innerRegisteredCount; i++) {
+      allocator.notifyRegistrationEnd();
+    }
+
+    allocator.markInternalRegistrationEnd();
+    // Inner Class
+    Assert.assertTrue(allocator.isInnerClass((short) innerRegisteredCount));
+    Assert.assertTrue(allocator.isInnerClass((short) (innerRegisteredCount - 1)));
+    Assert.assertTrue(allocator.isInnerClass((short) 1));
+
+    // Not Inner Class
+    Assert.assertFalse(allocator.isInnerClass(null));
+    Assert.assertFalse(allocator.isInnerClass(ClassIdAllocator.BuiltinClassId.NO_CLASS_ID));
+    Assert.assertFalse(allocator.isInnerClass((short) 12));
+  }
+
+  @Test
+  public void testAllocateClassId() {
+    final int registeredClassId = 3;
+    ClassIdAllocator allocator =
+        new ClassIdAllocator((cls) -> false, (classId) -> classId <= registeredClassId);
+    Assert.assertEquals(allocator.allocateClassId(this.getClass()), 4);
+  }
+}


### PR DESCRIPTION
To reduce the complexity of the `ClassResolver` class, we mainly do the following two things:

1. Move ClassId related responsibilities into ClassIdAllocator class.

2. Move `registeredId2ClassInfo` into `ExtRegistry` static inner class since they are content related.