### PR TITLE
ci: fix ci error

### DIFF
--- a/ci/run_ci.py
+++ b/ci/run_ci.py
@@ -115,6 +115,7 @@ def _run_js():
 def _install_cpp_deps():
     _exec_cmd(f"pip install pyarrow=={PYARROW_VERSION}")
     _exec_cmd("pip install psutil")
+    _exec_cmd("pip install 'numpy<2.0.0'")
     _install_bazel()
 
 

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -34,7 +34,7 @@ install_python() {
 install_pyfury() {
   echo "Python version $(python -V), path $(which python)"
   "$ROOT"/ci/deploy.sh install_pyarrow
-  pip install Cython wheel numpy pytest
+  pip install Cython wheel "numpy<2.0.0" pytest
   pushd "$ROOT/python"
   pip list
   export PATH=~/bin:$PATH


### PR DESCRIPTION
## What does this PR do?
The current CI keeps failing.

[Error](https://github.com/apache/fury/actions/runs/9560557264/job/26352935638):
```
  A module that was compiled using NumPy 1.x cannot be run in
  NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
  versions of NumPy, modules must be compiled with NumPy 2.0.
  Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
```

`numpy` was updated to 2.0.0 on Jun 16, 2024, which caused compatibility issues with CI, so `numpy<2.0.0` was set.

![image](https://github.com/apache/fury/assets/116876207/e89b9fcc-487e-4099-af12-218359863484)



## Related issues




## Does this PR introduce any user-facing change?


- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark
