### PR TITLE
fix(java): return fury to pooled which get from

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/pool/ClassLoaderFuryPooled.java
+++ b/java/fury-core/src/main/java/org/apache/fury/pool/ClassLoaderFuryPooled.java
@@ -109,6 +109,7 @@ public class ClassLoaderFuryPooled {
       furyCondition.signalAll();
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
+      throw new RuntimeException(e);
     } finally {
       lock.unlock();
     }

--- a/java/fury-core/src/main/java/org/apache/fury/pool/FuryPooledObjectFactory.java
+++ b/java/fury-core/src/main/java/org/apache/fury/pool/FuryPooledObjectFactory.java
@@ -81,33 +81,16 @@ public class FuryPooledObjectFactory {
         CacheBuilder.newBuilder().expireAfterAccess(expireTime, timeUnit).build();
   }
 
-  public Fury getFury() {
+  public ClassLoaderFuryPooled getPooledCache() {
     try {
       ClassLoader classLoader = classLoaderLocal.get();
       ClassLoaderFuryPooled classLoaderFuryPooled =
           classLoaderFuryPooledCache.getIfPresent(classLoader);
       if (classLoaderFuryPooled == null) {
         // double check cache
-        ClassLoaderFuryPooled cache = getOrAddCache(classLoader);
-        return cache.getFury();
+        return getOrAddCache(classLoader);
       }
-      return classLoaderFuryPooled.getFury();
-    } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
-      throw new RuntimeException(e);
-    }
-  }
-
-  public void returnFury(Fury fury) {
-    try {
-      ClassLoader classLoader = classLoaderLocal.get();
-      ClassLoaderFuryPooled classLoaderFuryPooled =
-          classLoaderFuryPooledCache.getIfPresent(classLoader);
-      if (classLoaderFuryPooled == null) {
-        // ifPresent will be cleared when cache expire 30's
-        return;
-      }
-      classLoaderFuryPooled.returnFury(fury);
+      return classLoaderFuryPooled;
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
       throw new RuntimeException(e);


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->

incase of pooledCache expired from cache, and fury will return to another pooledCache.
so we save pooledCache instead of get from cache.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
