### PR TITLE
refactor(java): move method from string serializer to string util

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -22,9 +22,11 @@ package org.apache.fury.meta;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import org.apache.fury.collection.Collections;
+import org.apache.fury.memory.Platform;
 import org.apache.fury.meta.MetaString.Encoding;
 import org.apache.fury.serializer.StringSerializer;
 import org.apache.fury.util.Preconditions;
+import org.apache.fury.util.StringUtils;
 
 /** Encodes plain text strings into MetaString objects with specified encoding mechanisms. */
 public class MetaStringEncoder {
@@ -57,7 +59,7 @@ public class MetaStringEncoder {
     if (input.isEmpty()) {
       return new MetaString(input, Encoding.UTF_8, specialChar1, specialChar2, new byte[0]);
     }
-    if (!StringSerializer.isLatin(input.toCharArray())) {
+    if (!StringUtils.isLatin(input.toCharArray(), Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
       return new MetaString(
           input,
           Encoding.UTF_8,
@@ -79,7 +81,8 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
-    if (encoding != Encoding.UTF_8 && !StringSerializer.isLatin(input.toCharArray())) {
+    if (encoding != Encoding.UTF_8 && !StringUtils.isLatin(input.toCharArray(),
+            Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -51,6 +51,7 @@ import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.type.Type;
 import org.apache.fury.util.ExceptionUtils;
 import org.apache.fury.util.GraalvmSupport;
+import org.apache.fury.util.StringUtils;
 import org.apache.fury.util.unsafe._JDKAccess;
 
 /** Serialization utils and common serializers. */
@@ -257,7 +258,7 @@ public class Serializers {
         buffer.writeBytes(v, 0, bytesLen);
       } else {
         char[] v = (char[]) GET_VALUE.apply(value);
-        if (StringSerializer.isLatin(v)) {
+        if (StringUtils.isLatin(v, Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
           stringSerializer.writeCharsLatin(buffer, v, value.length());
         } else {
           stringSerializer.writeCharsUTF16(buffer, v, value.length());

--- a/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.fury.util;
 
+import org.apache.fury.memory.Platform;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -249,4 +251,30 @@ public class StringUtils {
 
     return builder.toString();
   }
+
+    public static boolean isLatin(char[] chars, int charArrayOffset, long multiCharsNonLatinMask) {
+        int numChars = chars.length;
+        int vectorizedLen = numChars >> 2;
+        int vectorizedChars = vectorizedLen << 2;
+        int endOffset = charArrayOffset + (vectorizedChars << 1);
+        boolean isLatin = true;
+        for (int offset = charArrayOffset; offset < endOffset; offset += 8) {
+            // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
+            // See benchmark in CompressStringSuite.latinSuperWordCheck.
+            long multiChars = Platform.getLong(chars, offset);
+            if ((multiChars & multiCharsNonLatinMask) != 0) {
+                isLatin = false;
+                break;
+            }
+        }
+        if (isLatin) {
+            for (int i = vectorizedChars; i < numChars; i++) {
+                if (chars[i] > 0xFF) {
+                    isLatin = false;
+                    break;
+                }
+            }
+        }
+        return isLatin;
+    }
 }

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -351,24 +351,43 @@ public class StringSerializerTest extends FuryTestBase {
 
   @Test
   public void testLatinCheck() {
-    assertTrue(StringSerializer.isLatin("Fury".toCharArray()));
-    assertTrue(StringSerializer.isLatin(StringUtils.random(8 * 10).toCharArray()));
+    int charArrayOffset = Platform.CHAR_ARRAY_OFFSET;
+    long multiCharsNonLatinMask = StringSerializer.MULTI_CHARS_NON_LATIN_MASK;
+    assertTrue(StringUtils.isLatin("Fury".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin(StringUtils.random(8 * 10).toCharArray(), charArrayOffset
+            , multiCharsNonLatinMask));
     // test unaligned
-    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "1").toCharArray()));
-    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "12").toCharArray()));
-    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "123").toCharArray()));
-    assertFalse(StringSerializer.isLatin("你好, Fury".toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(11) + "你").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(10) + "你好").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(9) + "性能好").toCharArray()));
-    assertFalse(StringSerializer.isLatin("\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("a\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("ab\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("abc\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("abcd\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("Javaone Keynote\u1234".toCharArray()));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "1").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "12").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "123").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("你好, Fury".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(11) + "你").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(10) + "你好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(9) + "性能好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("a\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("ab\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("abc\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("abcd\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("Javaone Keynote\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
   }
 
   @Test


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR moves decouples and moves the isLatin method from StringSerializer class to StringUtils.


## Related issues

<!--
Is there any related issue? Please attach here.

- #1703
- #xxxx1
- #xxxx2
-->
#1703


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
