### PR TITLE
refactor(java): move latin language checker method from string serializer to string util

### DIFF
--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
@@ -102,7 +102,7 @@ public class CompressStringSuite {
 
   @Benchmark
   public Object latinSuperWordCheck() {
-    return StringSerializer.isLatin(latinStrChars);
+      return StringUtils.isLatin(latinStrChars, Platform.Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK);
   }
 
   public static void main(String[] args) throws Exception {

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
@@ -22,7 +22,6 @@ package org.apache.fury.benchmark;
 import java.nio.ByteBuffer;
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.memory.Platform;
-import org.apache.fury.serializer.StringSerializer;
 import org.apache.fury.util.StringUtils;
 import org.openjdk.jmh.Main;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -102,7 +101,7 @@ public class CompressStringSuite {
 
   @Benchmark
   public Object latinSuperWordCheck() {
-      return StringUtils.isLatin(latinStrChars);
+    return StringUtils.isLatin(latinStrChars);
   }
 
   public static void main(String[] args) throws Exception {

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
@@ -102,7 +102,7 @@ public class CompressStringSuite {
 
   @Benchmark
   public Object latinSuperWordCheck() {
-      return StringUtils.isLatin(latinStrChars, Platform.Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK);
+      return StringUtils.isLatin(latinStrChars, Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK);
   }
 
   public static void main(String[] args) throws Exception {

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
@@ -102,7 +102,7 @@ public class CompressStringSuite {
 
   @Benchmark
   public Object latinSuperWordCheck() {
-      return StringUtils.isLatin(latinStrChars, Platform.CHAR_ARRAY_OFFSET);
+      return StringUtils.isLatin(latinStrChars);
   }
 
   public static void main(String[] args) throws Exception {

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/CompressStringSuite.java
@@ -102,7 +102,7 @@ public class CompressStringSuite {
 
   @Benchmark
   public Object latinSuperWordCheck() {
-      return StringUtils.isLatin(latinStrChars, Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK);
+      return StringUtils.isLatin(latinStrChars, Platform.CHAR_ARRAY_OFFSET);
   }
 
   public static void main(String[] args) throws Exception {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -22,7 +22,6 @@ package org.apache.fury.meta;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import org.apache.fury.collection.Collections;
-import org.apache.fury.memory.Platform;
 import org.apache.fury.meta.MetaString.Encoding;
 import org.apache.fury.util.Preconditions;
 import org.apache.fury.util.StringUtils;
@@ -58,7 +57,7 @@ public class MetaStringEncoder {
     if (input.isEmpty()) {
       return new MetaString(input, Encoding.UTF_8, specialChar1, specialChar2, new byte[0]);
     }
-    if (!StringUtils.isLatin(input.toCharArray(), Platform.CHAR_ARRAY_OFFSET)) {
+    if (!StringUtils.isLatin(input.toCharArray())) {
       return new MetaString(
           input,
           Encoding.UTF_8,
@@ -80,8 +79,7 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
-    if (encoding != Encoding.UTF_8
-        && !StringUtils.isLatin(input.toCharArray(), Platform.CHAR_ARRAY_OFFSET)) {
+    if (encoding != Encoding.UTF_8 && !StringUtils.isLatin(input.toCharArray())) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import org.apache.fury.collection.Collections;
 import org.apache.fury.memory.Platform;
 import org.apache.fury.meta.MetaString.Encoding;
-import org.apache.fury.serializer.StringSerializer;
 import org.apache.fury.util.Preconditions;
 import org.apache.fury.util.StringUtils;
 
@@ -59,10 +58,7 @@ public class MetaStringEncoder {
     if (input.isEmpty()) {
       return new MetaString(input, Encoding.UTF_8, specialChar1, specialChar2, new byte[0]);
     }
-    if (!StringUtils.isLatin(
-        input.toCharArray(),
-        Platform.CHAR_ARRAY_OFFSET,
-        StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
+    if (!StringUtils.isLatin(input.toCharArray(), Platform.CHAR_ARRAY_OFFSET)) {
       return new MetaString(
           input,
           Encoding.UTF_8,
@@ -85,10 +81,7 @@ public class MetaStringEncoder {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
     if (encoding != Encoding.UTF_8
-        && !StringUtils.isLatin(
-            input.toCharArray(),
-            Platform.CHAR_ARRAY_OFFSET,
-            StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
+        && !StringUtils.isLatin(input.toCharArray(), Platform.CHAR_ARRAY_OFFSET)) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -59,7 +59,10 @@ public class MetaStringEncoder {
     if (input.isEmpty()) {
       return new MetaString(input, Encoding.UTF_8, specialChar1, specialChar2, new byte[0]);
     }
-    if (!StringUtils.isLatin(input.toCharArray(), Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
+    if (!StringUtils.isLatin(
+        input.toCharArray(),
+        Platform.CHAR_ARRAY_OFFSET,
+        StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
       return new MetaString(
           input,
           Encoding.UTF_8,
@@ -81,8 +84,11 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
-    if (encoding != Encoding.UTF_8 && !StringUtils.isLatin(input.toCharArray(),
-            Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
+    if (encoding != Encoding.UTF_8
+        && !StringUtils.isLatin(
+            input.toCharArray(),
+            Platform.CHAR_ARRAY_OFFSET,
+            StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -22,9 +22,11 @@ package org.apache.fury.meta;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import org.apache.fury.collection.Collections;
+import org.apache.fury.memory.Platform;
 import org.apache.fury.meta.MetaString.Encoding;
 import org.apache.fury.serializer.StringSerializer;
 import org.apache.fury.util.Preconditions;
+import org.apache.fury.util.StringUtils;
 
 /** Encodes plain text strings into MetaString objects with specified encoding mechanisms. */
 public class MetaStringEncoder {
@@ -57,7 +59,7 @@ public class MetaStringEncoder {
     if (input.isEmpty()) {
       return new MetaString(input, Encoding.UTF_8, specialChar1, specialChar2, new byte[0]);
     }
-    if (!StringSerializer.isLatin(input.toCharArray())) {
+    if (!StringUtils.isLatin(input.toCharArray(), Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
       return new MetaString(
           input,
           Encoding.UTF_8,
@@ -79,7 +81,8 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
-    if (encoding != Encoding.UTF_8 && !StringSerializer.isLatin(input.toCharArray())) {
+    if (encoding != Encoding.UTF_8 && !StringUtils.isLatin(input.toCharArray(),
+            Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -258,7 +258,8 @@ public class Serializers {
         buffer.writeBytes(v, 0, bytesLen);
       } else {
         char[] v = (char[]) GET_VALUE.apply(value);
-        if (StringUtils.isLatin(v, Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
+        if (StringUtils.isLatin(
+            v, Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
           stringSerializer.writeCharsLatin(buffer, v, value.length());
         } else {
           stringSerializer.writeCharsUTF16(buffer, v, value.length());

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -51,6 +51,7 @@ import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.type.Type;
 import org.apache.fury.util.ExceptionUtils;
 import org.apache.fury.util.GraalvmSupport;
+import org.apache.fury.util.StringUtils;
 import org.apache.fury.util.unsafe._JDKAccess;
 
 /** Serialization utils and common serializers. */
@@ -257,7 +258,7 @@ public class Serializers {
         buffer.writeBytes(v, 0, bytesLen);
       } else {
         char[] v = (char[]) GET_VALUE.apply(value);
-        if (StringSerializer.isLatin(v)) {
+        if (StringUtils.isLatin(v, Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
           stringSerializer.writeCharsLatin(buffer, v, value.length());
         } else {
           stringSerializer.writeCharsUTF16(buffer, v, value.length());

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -258,7 +258,7 @@ public class Serializers {
         buffer.writeBytes(v, 0, bytesLen);
       } else {
         char[] v = (char[]) GET_VALUE.apply(value);
-        if (StringUtils.isLatin(v, Platform.CHAR_ARRAY_OFFSET)) {
+        if (StringUtils.isLatin(v)) {
           stringSerializer.writeCharsLatin(buffer, v, value.length());
         } else {
           stringSerializer.writeCharsUTF16(buffer, v, value.length());

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -258,8 +258,7 @@ public class Serializers {
         buffer.writeBytes(v, 0, bytesLen);
       } else {
         char[] v = (char[]) GET_VALUE.apply(value);
-        if (StringUtils.isLatin(
-            v, Platform.CHAR_ARRAY_OFFSET, StringSerializer.MULTI_CHARS_NON_LATIN_MASK)) {
+        if (StringUtils.isLatin(v, Platform.CHAR_ARRAY_OFFSET)) {
           stringSerializer.writeCharsLatin(buffer, v, value.length());
         } else {
           stringSerializer.writeCharsUTF16(buffer, v, value.length());

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -301,7 +301,7 @@ public final class StringSerializer extends Serializer<String> {
     }
   }
 
-    // Invoked by fury JIT
+  // Invoked by fury JIT
   public String readJavaString(MemoryBuffer buffer) {
     if (STRING_VALUE_FIELD_IS_BYTES) {
       return readBytesString(buffer);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -64,8 +64,6 @@ public final class StringSerializer extends Serializer<String> {
   private static final Byte UTF16_BOXED = UTF16;
   private static final byte UTF8 = 2;
   private static final int DEFAULT_BUFFER_SIZE = 1024;
-  // A long mask used to clear all-higher bits of char in a super-word way.
-  public static final long MULTI_CHARS_NON_LATIN_MASK;
 
   // Make offset compatible with graalvm native image.
   private static final long STRING_VALUE_FIELD_OFFSET;
@@ -104,15 +102,6 @@ public final class StringSerializer extends Serializer<String> {
     Preconditions.checkArgument(
         ReflectionUtils.getFieldNullable(String.class, "offset") == null,
         "Current jdk not supported");
-    if (Platform.IS_LITTLE_ENDIAN) {
-      // latin chars will be 0xXX,0x00;0xXX,0x00 in byte order;
-      // Using 0x00,0xff(0xff00) to clear latin bits.
-      MULTI_CHARS_NON_LATIN_MASK = 0xff00ff00ff00ff00L;
-    } else {
-      // latin chars will be 0x00,0xXX;0x00,0xXX in byte order;
-      // Using 0x00,0xff(0x00ff) to clear latin bits.
-      MULTI_CHARS_NON_LATIN_MASK = 0x00ff00ff00ff00ffL;
-    }
   }
 
   private final boolean compressString;
@@ -179,7 +168,7 @@ public final class StringSerializer extends Serializer<String> {
   // Invoked by jit
   public void writeCharsStringCompressed(MemoryBuffer buffer, String value) {
     final char[] chars = (char[]) Platform.getObject(value, STRING_VALUE_FIELD_OFFSET);
-    if (StringUtils.isLatin(chars, Platform.CHAR_ARRAY_OFFSET, MULTI_CHARS_NON_LATIN_MASK)) {
+    if (StringUtils.isLatin(chars, Platform.CHAR_ARRAY_OFFSET)) {
       writeCharsLatin(buffer, chars, chars.length);
     } else {
       writeCharsUTF16(buffer, chars, chars.length);
@@ -289,7 +278,7 @@ public final class StringSerializer extends Serializer<String> {
       assert STRING_VALUE_FIELD_IS_CHARS;
       final char[] chars = (char[]) Platform.getObject(value, STRING_VALUE_FIELD_OFFSET);
       if (compressString) {
-        if (StringUtils.isLatin(chars, Platform.CHAR_ARRAY_OFFSET, MULTI_CHARS_NON_LATIN_MASK)) {
+        if (StringUtils.isLatin(chars, Platform.CHAR_ARRAY_OFFSET)) {
           writeCharsLatin(buffer, chars, chars.length);
         } else {
           writeCharsUTF16(buffer, chars, chars.length);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -168,7 +168,7 @@ public final class StringSerializer extends Serializer<String> {
   // Invoked by jit
   public void writeCharsStringCompressed(MemoryBuffer buffer, String value) {
     final char[] chars = (char[]) Platform.getObject(value, STRING_VALUE_FIELD_OFFSET);
-    if (StringUtils.isLatin(chars, Platform.CHAR_ARRAY_OFFSET)) {
+    if (StringUtils.isLatin(chars)) {
       writeCharsLatin(buffer, chars, chars.length);
     } else {
       writeCharsUTF16(buffer, chars, chars.length);
@@ -278,7 +278,7 @@ public final class StringSerializer extends Serializer<String> {
       assert STRING_VALUE_FIELD_IS_CHARS;
       final char[] chars = (char[]) Platform.getObject(value, STRING_VALUE_FIELD_OFFSET);
       if (compressString) {
-        if (StringUtils.isLatin(chars, Platform.CHAR_ARRAY_OFFSET)) {
+        if (StringUtils.isLatin(chars)) {
           writeCharsLatin(buffer, chars, chars.length);
         } else {
           writeCharsUTF16(buffer, chars, chars.length);

--- a/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
@@ -26,7 +26,7 @@ import org.apache.fury.memory.Platform;
 
 public class StringUtils {
   // A long mask used to clear all-higher bits of char in a super-word way.
-  public static final long MULTI_CHARS_NON_LATIN_MASK;
+  private static final long MULTI_CHARS_NON_LATIN_MASK;
 
   private static final char[] BASE16_CHARS2 = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'

--- a/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
@@ -19,11 +19,10 @@
 
 package org.apache.fury.util;
 
-import org.apache.fury.memory.Platform;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import org.apache.fury.memory.Platform;
 
 public class StringUtils {
   private static final char[] BASE16_CHARS2 = {
@@ -252,29 +251,29 @@ public class StringUtils {
     return builder.toString();
   }
 
-    public static boolean isLatin(char[] chars, int charArrayOffset, long multiCharsNonLatinMask) {
-        int numChars = chars.length;
-        int vectorizedLen = numChars >> 2;
-        int vectorizedChars = vectorizedLen << 2;
-        int endOffset = charArrayOffset + (vectorizedChars << 1);
-        boolean isLatin = true;
-        for (int offset = charArrayOffset; offset < endOffset; offset += 8) {
-            // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
-            // See benchmark in CompressStringSuite.latinSuperWordCheck.
-            long multiChars = Platform.getLong(chars, offset);
-            if ((multiChars & multiCharsNonLatinMask) != 0) {
-                isLatin = false;
-                break;
-            }
-        }
-        if (isLatin) {
-            for (int i = vectorizedChars; i < numChars; i++) {
-                if (chars[i] > 0xFF) {
-                    isLatin = false;
-                    break;
-                }
-            }
-        }
-        return isLatin;
+  public static boolean isLatin(char[] chars, int charArrayOffset, long multiCharsNonLatinMask) {
+    int numChars = chars.length;
+    int vectorizedLen = numChars >> 2;
+    int vectorizedChars = vectorizedLen << 2;
+    int endOffset = charArrayOffset + (vectorizedChars << 1);
+    boolean isLatin = true;
+    for (int offset = charArrayOffset; offset < endOffset; offset += 8) {
+      // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
+      // See benchmark in CompressStringSuite.latinSuperWordCheck.
+      long multiChars = Platform.getLong(chars, offset);
+      if ((multiChars & multiCharsNonLatinMask) != 0) {
+        isLatin = false;
+        break;
+      }
     }
+    if (isLatin) {
+      for (int i = vectorizedChars; i < numChars; i++) {
+        if (chars[i] > 0xFF) {
+          isLatin = false;
+          break;
+        }
+      }
+    }
+    return isLatin;
+  }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.fury.util;
 
+import org.apache.fury.memory.Platform;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -249,4 +251,30 @@ public class StringUtils {
 
     return builder.toString();
   }
+
+    public static boolean isLatin(char[] chars, int charArrayOffset, long multiCharsNonLatinMask) {
+        int numChars = chars.length;
+        int vectorizedLen = numChars >> 2;
+        int vectorizedChars = vectorizedLen << 2;
+        int endOffset = charArrayOffset + (vectorizedChars << 1);
+        boolean isLatin = true;
+        for (int offset = charArrayOffset; offset < endOffset; offset += 8) {
+            // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
+            // See benchmark in CompressStringSuite.latinSuperWordCheck.
+            long multiChars = Platform.getLong(chars, offset);
+            if ((multiChars & multiCharsNonLatinMask) != 0) {
+                isLatin = false;
+                break;
+            }
+        }
+        if (isLatin) {
+            for (int i = vectorizedChars; i < numChars; i++) {
+                if (chars[i] > 0xFF) {
+                    isLatin = false;
+                    break;
+                }
+            }
+        }
+        return isLatin;
+    }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
@@ -266,13 +266,13 @@ public class StringUtils {
     return builder.toString();
   }
 
-  public static boolean isLatin(char[] chars, int charArrayOffset) {
+  public static boolean isLatin(char[] chars) {
     int numChars = chars.length;
     int vectorizedLen = numChars >> 2;
     int vectorizedChars = vectorizedLen << 2;
-    int endOffset = charArrayOffset + (vectorizedChars << 1);
+    int endOffset = Platform.CHAR_ARRAY_OFFSET + (vectorizedChars << 1);
     boolean isLatin = true;
-    for (int offset = charArrayOffset; offset < endOffset; offset += 8) {
+    for (int offset = Platform.CHAR_ARRAY_OFFSET; offset < endOffset; offset += 8) {
       // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
       // See benchmark in CompressStringSuite.latinSuperWordCheck.
       long multiChars = Platform.getLong(chars, offset);

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -172,4 +172,5 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.reflect.Types$ClassOwnership,\
     org.apache.fury.reflect.Types$ClassOwnership$1,\
     org.apache.fury.reflect.Types$ClassOwnership$2,\
-    org.apache.fury.resolver.DisallowedList
+    org.apache.fury.resolver.DisallowedList,\
+    org.apache.fury.util.StringUtils

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -21,8 +21,6 @@ package org.apache.fury.serializer;
 
 import static org.apache.fury.serializer.StringSerializer.newBytesStringZeroCopy;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -288,95 +286,6 @@ public class StringSerializerTest extends FuryTestBase {
       assertEquals(stringSerializer.readJavaString(buffer), latinStr);
       assertEquals(buffer.writerIndex(), buffer.readerIndex());
     }
-  }
-
-  @Test(dataProvider = "endian")
-  public void testVectorizedLatinCheckAlgorithm(boolean endian) {
-    // assertTrue(isLatin("Fury".toCharArray(), endian));
-    // assertTrue(isLatin(StringUtils.random(8 * 10).toCharArray(), endian));
-    // test unaligned
-    assertTrue(isLatin((StringUtils.random(8 * 10) + "1").toCharArray(), endian));
-    assertTrue(isLatin((StringUtils.random(8 * 10) + "12").toCharArray(), endian));
-    assertTrue(isLatin((StringUtils.random(8 * 10) + "123").toCharArray(), endian));
-    assertFalse(isLatin("你好, Fury".toCharArray(), endian));
-    assertFalse(isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(), endian));
-    assertFalse(isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(), endian));
-  }
-
-  private boolean isLatin(char[] chars, boolean isLittle) {
-    boolean reverseBytes =
-        (Platform.IS_LITTLE_ENDIAN && !isLittle) || (!Platform.IS_LITTLE_ENDIAN && !isLittle);
-    if (reverseBytes) {
-      for (int i = 0; i < chars.length; i++) {
-        chars[i] = Character.reverseBytes(chars[i]);
-      }
-    }
-    long mask;
-    if (isLittle) {
-      // latin chars will be 0xXX,0x00;0xXX,0x00 in byte order;
-      // Using 0x00,0xff(0xff00) to clear latin bits.
-      mask = 0xff00ff00ff00ff00L;
-    } else {
-      // latin chars will be 0x00,0xXX;0x00,0xXX in byte order;
-      // Using 0x00,0xff(0x00ff) to clear latin bits.
-      mask = 0x00ff00ff00ff00ffL;
-    }
-    int numChars = chars.length;
-    int vectorizedLen = numChars >> 2;
-    int vectorizedChars = vectorizedLen << 2;
-    int endOffset = Platform.CHAR_ARRAY_OFFSET + (vectorizedChars << 1);
-    boolean isLatin = true;
-    for (int offset = Platform.CHAR_ARRAY_OFFSET; offset < endOffset; offset += 8) {
-      // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
-      long multiChars = Platform.getLong(chars, offset);
-      if ((multiChars & mask) != 0) {
-        isLatin = false;
-        break;
-      }
-    }
-    if (isLatin) {
-      for (int i = vectorizedChars; i < numChars; i++) {
-        char c = chars[i];
-        if (reverseBytes) {
-          c = Character.reverseBytes(c);
-        }
-        if (c > 0xFF) {
-          isLatin = false;
-          break;
-        }
-      }
-    }
-    return isLatin;
-  }
-
-  @Test
-  public void testLatinCheck() {
-    int charArrayOffset = Platform.CHAR_ARRAY_OFFSET;
-    assertTrue(StringUtils.isLatin("Fury".toCharArray(), charArrayOffset));
-    assertTrue(StringUtils.isLatin(StringUtils.random(8 * 10).toCharArray(), charArrayOffset));
-    // test unaligned
-    assertTrue(
-        StringUtils.isLatin((StringUtils.random(8 * 10) + "1").toCharArray(), charArrayOffset));
-    assertTrue(
-        StringUtils.isLatin((StringUtils.random(8 * 10) + "12").toCharArray(), charArrayOffset));
-    assertTrue(
-        StringUtils.isLatin((StringUtils.random(8 * 10) + "123").toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin("你好, Fury".toCharArray(), charArrayOffset));
-    assertFalse(
-        StringUtils.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(), charArrayOffset));
-    assertFalse(
-        StringUtils.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin((StringUtils.random(11) + "你").toCharArray(), charArrayOffset));
-    assertFalse(
-        StringUtils.isLatin((StringUtils.random(10) + "你好").toCharArray(), charArrayOffset));
-    assertFalse(
-        StringUtils.isLatin((StringUtils.random(9) + "性能好").toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin("\u1234".toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin("a\u1234".toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin("ab\u1234".toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin("abc\u1234".toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin("abcd\u1234".toCharArray(), charArrayOffset));
-    assertFalse(StringUtils.isLatin("Javaone Keynote\u1234".toCharArray(), charArrayOffset));
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -353,41 +353,64 @@ public class StringSerializerTest extends FuryTestBase {
   public void testLatinCheck() {
     int charArrayOffset = Platform.CHAR_ARRAY_OFFSET;
     long multiCharsNonLatinMask = StringSerializer.MULTI_CHARS_NON_LATIN_MASK;
-    assertTrue(StringUtils.isLatin("Fury".toCharArray(), charArrayOffset,
-            multiCharsNonLatinMask));
-    assertTrue(StringUtils.isLatin(StringUtils.random(8 * 10).toCharArray(), charArrayOffset
-            , multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin("Fury".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertTrue(
+        StringUtils.isLatin(
+            StringUtils.random(8 * 10).toCharArray(), charArrayOffset, multiCharsNonLatinMask));
     // test unaligned
-    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "1").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "12").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "123").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin("你好, Fury".toCharArray(), charArrayOffset,
+    assertTrue(
+        StringUtils.isLatin(
+            (StringUtils.random(8 * 10) + "1").toCharArray(),
+            charArrayOffset,
             multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin((StringUtils.random(11) + "你").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin((StringUtils.random(10) + "你好").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin((StringUtils.random(9) + "性能好").toCharArray(),
-            charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin("\u1234".toCharArray(), charArrayOffset,
+    assertTrue(
+        StringUtils.isLatin(
+            (StringUtils.random(8 * 10) + "12").toCharArray(),
+            charArrayOffset,
             multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin("a\u1234".toCharArray(), charArrayOffset,
+    assertTrue(
+        StringUtils.isLatin(
+            (StringUtils.random(8 * 10) + "123").toCharArray(),
+            charArrayOffset,
             multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin("ab\u1234".toCharArray(), charArrayOffset,
+    assertFalse(
+        StringUtils.isLatin("你好, Fury".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin(
+            (StringUtils.random(8 * 10) + "你好").toCharArray(),
+            charArrayOffset,
             multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin("abc\u1234".toCharArray(), charArrayOffset,
+    assertFalse(
+        StringUtils.isLatin(
+            (StringUtils.random(8 * 10) + "1你好").toCharArray(),
+            charArrayOffset,
             multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin("abcd\u1234".toCharArray(), charArrayOffset,
+    assertFalse(
+        StringUtils.isLatin(
+            (StringUtils.random(11) + "你").toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin(
+            (StringUtils.random(10) + "你好").toCharArray(),
+            charArrayOffset,
             multiCharsNonLatinMask));
-    assertFalse(StringUtils.isLatin("Javaone Keynote\u1234".toCharArray(), charArrayOffset,
+    assertFalse(
+        StringUtils.isLatin(
+            (StringUtils.random(9) + "性能好").toCharArray(),
+            charArrayOffset,
             multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin("\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin("a\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin("ab\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin("abc\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin("abcd\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(
+        StringUtils.isLatin(
+            "Javaone Keynote\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -351,24 +351,43 @@ public class StringSerializerTest extends FuryTestBase {
 
   @Test
   public void testLatinCheck() {
-    assertTrue(StringSerializer.isLatin("Fury".toCharArray()));
-    assertTrue(StringSerializer.isLatin(StringUtils.random(8 * 10).toCharArray()));
+    int charArrayOffset = Platform.CHAR_ARRAY_OFFSET;
+    long multiCharsNonLatinMask = StringSerializer.MULTI_CHARS_NON_LATIN_MASK;
+    assertTrue(StringUtils.isLatin("Fury".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin(StringUtils.random(8 * 10).toCharArray(), charArrayOffset
+            , multiCharsNonLatinMask));
     // test unaligned
-    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "1").toCharArray()));
-    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "12").toCharArray()));
-    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "123").toCharArray()));
-    assertFalse(StringSerializer.isLatin("你好, Fury".toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(11) + "你").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(10) + "你好").toCharArray()));
-    assertFalse(StringSerializer.isLatin((StringUtils.random(9) + "性能好").toCharArray()));
-    assertFalse(StringSerializer.isLatin("\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("a\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("ab\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("abc\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("abcd\u1234".toCharArray()));
-    assertFalse(StringSerializer.isLatin("Javaone Keynote\u1234".toCharArray()));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "1").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "12").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "123").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("你好, Fury".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(11) + "你").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(10) + "你好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin((StringUtils.random(9) + "性能好").toCharArray(),
+            charArrayOffset, multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("a\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("ab\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("abc\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("abcd\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
+    assertFalse(StringUtils.isLatin("Javaone Keynote\u1234".toCharArray(), charArrayOffset,
+            multiCharsNonLatinMask));
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -352,65 +352,31 @@ public class StringSerializerTest extends FuryTestBase {
   @Test
   public void testLatinCheck() {
     int charArrayOffset = Platform.CHAR_ARRAY_OFFSET;
-    long multiCharsNonLatinMask = StringSerializer.MULTI_CHARS_NON_LATIN_MASK;
-    assertTrue(StringUtils.isLatin("Fury".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
-    assertTrue(
-        StringUtils.isLatin(
-            StringUtils.random(8 * 10).toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+    assertTrue(StringUtils.isLatin("Fury".toCharArray(), charArrayOffset));
+    assertTrue(StringUtils.isLatin(StringUtils.random(8 * 10).toCharArray(), charArrayOffset));
     // test unaligned
     assertTrue(
-        StringUtils.isLatin(
-            (StringUtils.random(8 * 10) + "1").toCharArray(),
-            charArrayOffset,
-            multiCharsNonLatinMask));
+        StringUtils.isLatin((StringUtils.random(8 * 10) + "1").toCharArray(), charArrayOffset));
     assertTrue(
-        StringUtils.isLatin(
-            (StringUtils.random(8 * 10) + "12").toCharArray(),
-            charArrayOffset,
-            multiCharsNonLatinMask));
+        StringUtils.isLatin((StringUtils.random(8 * 10) + "12").toCharArray(), charArrayOffset));
     assertTrue(
-        StringUtils.isLatin(
-            (StringUtils.random(8 * 10) + "123").toCharArray(),
-            charArrayOffset,
-            multiCharsNonLatinMask));
+        StringUtils.isLatin((StringUtils.random(8 * 10) + "123").toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin("你好, Fury".toCharArray(), charArrayOffset));
     assertFalse(
-        StringUtils.isLatin("你好, Fury".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+        StringUtils.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(), charArrayOffset));
     assertFalse(
-        StringUtils.isLatin(
-            (StringUtils.random(8 * 10) + "你好").toCharArray(),
-            charArrayOffset,
-            multiCharsNonLatinMask));
+        StringUtils.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin((StringUtils.random(11) + "你").toCharArray(), charArrayOffset));
     assertFalse(
-        StringUtils.isLatin(
-            (StringUtils.random(8 * 10) + "1你好").toCharArray(),
-            charArrayOffset,
-            multiCharsNonLatinMask));
+        StringUtils.isLatin((StringUtils.random(10) + "你好").toCharArray(), charArrayOffset));
     assertFalse(
-        StringUtils.isLatin(
-            (StringUtils.random(11) + "你").toCharArray(), charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin(
-            (StringUtils.random(10) + "你好").toCharArray(),
-            charArrayOffset,
-            multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin(
-            (StringUtils.random(9) + "性能好").toCharArray(),
-            charArrayOffset,
-            multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin("\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin("a\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin("ab\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin("abc\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin("abcd\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
-    assertFalse(
-        StringUtils.isLatin(
-            "Javaone Keynote\u1234".toCharArray(), charArrayOffset, multiCharsNonLatinMask));
+        StringUtils.isLatin((StringUtils.random(9) + "性能好").toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin("\u1234".toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin("a\u1234".toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin("ab\u1234".toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin("abc\u1234".toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin("abcd\u1234".toCharArray(), charArrayOffset));
+    assertFalse(StringUtils.isLatin("Javaone Keynote\u1234".toCharArray(), charArrayOffset));
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/util/StringUtilsTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/util/StringUtilsTest.java
@@ -23,9 +23,11 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import org.apache.fury.FuryTestBase;
+import org.apache.fury.memory.Platform;
 import org.testng.annotations.Test;
 
-public class StringUtilsTest {
+public class StringUtilsTest extends FuryTestBase {
 
   @Test
   public void testEncodeHexString() {
@@ -86,5 +88,86 @@ public class StringUtilsTest {
     assertEquals(StringUtils.lowerCamelToLowerUnderscore("someLongVariable"), "some_long_variable");
     assertEquals(StringUtils.lowerCamelToLowerUnderscore("some123variable"), "some123variable");
     assertEquals(StringUtils.lowerCamelToLowerUnderscore("someVariable123"), "some_variable123");
+  }
+
+  @Test(dataProvider = "endian")
+  public void testVectorizedLatinCheckAlgorithm(boolean endian) {
+    // assertTrue(isLatin("Fury".toCharArray(), endian));
+    // assertTrue(isLatin(StringUtils.random(8 * 10).toCharArray(), endian));
+    // test unaligned
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "1").toCharArray(), endian));
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "12").toCharArray(), endian));
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "123").toCharArray(), endian));
+    assertFalse(isLatin("你好, Fury".toCharArray(), endian));
+    assertFalse(isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(), endian));
+    assertFalse(isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(), endian));
+  }
+
+  private boolean isLatin(char[] chars, boolean isLittle) {
+    boolean reverseBytes =
+        (Platform.IS_LITTLE_ENDIAN && !isLittle) || (!Platform.IS_LITTLE_ENDIAN && !isLittle);
+    if (reverseBytes) {
+      for (int i = 0; i < chars.length; i++) {
+        chars[i] = Character.reverseBytes(chars[i]);
+      }
+    }
+    long mask;
+    if (isLittle) {
+      // latin chars will be 0xXX,0x00;0xXX,0x00 in byte order;
+      // Using 0x00,0xff(0xff00) to clear latin bits.
+      mask = 0xff00ff00ff00ff00L;
+    } else {
+      // latin chars will be 0x00,0xXX;0x00,0xXX in byte order;
+      // Using 0x00,0xff(0x00ff) to clear latin bits.
+      mask = 0x00ff00ff00ff00ffL;
+    }
+    int numChars = chars.length;
+    int vectorizedLen = numChars >> 2;
+    int vectorizedChars = vectorizedLen << 2;
+    int endOffset = Platform.CHAR_ARRAY_OFFSET + (vectorizedChars << 1);
+    boolean isLatin = true;
+    for (int offset = Platform.CHAR_ARRAY_OFFSET; offset < endOffset; offset += 8) {
+      // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
+      long multiChars = Platform.getLong(chars, offset);
+      if ((multiChars & mask) != 0) {
+        isLatin = false;
+        break;
+      }
+    }
+    if (isLatin) {
+      for (int i = vectorizedChars; i < numChars; i++) {
+        char c = chars[i];
+        if (reverseBytes) {
+          c = Character.reverseBytes(c);
+        }
+        if (c > 0xFF) {
+          isLatin = false;
+          break;
+        }
+      }
+    }
+    return isLatin;
+  }
+
+  @Test
+  public void testLatinCheck() {
+    assertTrue(StringUtils.isLatin("Fury".toCharArray()));
+    assertTrue(StringUtils.isLatin(StringUtils.random(8 * 10).toCharArray()));
+    // test unaligned
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "1").toCharArray()));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "12").toCharArray()));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "123").toCharArray()));
+    assertFalse(StringUtils.isLatin("你好, Fury".toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(11) + "你").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(10) + "你好").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(9) + "性能好").toCharArray()));
+    assertFalse(StringUtils.isLatin("\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("a\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("ab\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("abc\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("abcd\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("Javaone Keynote\u1234".toCharArray()));
   }
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
This PR decouples and moves the `isLatin([])` method from `StringSerializer` class to `StringUtils`.


## Related issues

<!--
Is there any related issue? Please attach here.

- #1703
- #xxxx1
- #xxxx2
-->
#1703


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
