### PR TITLE
refactor(java): move isLatin from StringSerializer to StringUtils

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -23,8 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import org.apache.fury.collection.Collections;
 import org.apache.fury.meta.MetaString.Encoding;
-import org.apache.fury.serializer.StringSerializer;
 import org.apache.fury.util.Preconditions;
+import org.apache.fury.util.StringUtils;
 
 /** Encodes plain text strings into MetaString objects with specified encoding mechanisms. */
 public class MetaStringEncoder {
@@ -57,7 +57,7 @@ public class MetaStringEncoder {
     if (input.isEmpty()) {
       return new MetaString(input, Encoding.UTF_8, specialChar1, specialChar2, new byte[0]);
     }
-    if (!StringSerializer.isLatin(input.toCharArray())) {
+    if (!StringUtils.isLatin(input.toCharArray())) {
       return new MetaString(
           input,
           Encoding.UTF_8,
@@ -79,7 +79,7 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
-    if (encoding != Encoding.UTF_8 && !StringSerializer.isLatin(input.toCharArray())) {
+    if (encoding != Encoding.UTF_8 && !StringUtils.isLatin(input.toCharArray())) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -51,6 +51,7 @@ import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.type.Type;
 import org.apache.fury.util.ExceptionUtils;
 import org.apache.fury.util.GraalvmSupport;
+import org.apache.fury.util.StringUtils;
 import org.apache.fury.util.unsafe._JDKAccess;
 
 /** Serialization utils and common serializers. */
@@ -257,7 +258,7 @@ public class Serializers {
         buffer.writeBytes(v, 0, bytesLen);
       } else {
         char[] v = (char[]) GET_VALUE.apply(value);
-        if (StringSerializer.isLatin(v)) {
+        if (StringUtils.isLatin(v)) {
           stringSerializer.writeCharsLatin(buffer, v, value.length());
         } else {
           stringSerializer.writeCharsUTF16(buffer, v, value.length());

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -43,6 +43,7 @@ import org.apache.fury.reflect.ReflectionUtils;
 import org.apache.fury.type.Type;
 import org.apache.fury.util.MathUtils;
 import org.apache.fury.util.Preconditions;
+import org.apache.fury.util.StringUtils;
 import org.apache.fury.util.unsafe._JDKAccess;
 
 /**
@@ -178,7 +179,7 @@ public final class StringSerializer extends Serializer<String> {
   // Invoked by jit
   public void writeCharsStringCompressed(MemoryBuffer buffer, String value) {
     final char[] chars = (char[]) Platform.getObject(value, STRING_VALUE_FIELD_OFFSET);
-    if (isLatin(chars)) {
+    if (StringUtils.isLatin(chars)) {
       writeCharsLatin(buffer, chars, chars.length);
     } else {
       writeCharsUTF16(buffer, chars, chars.length);
@@ -288,7 +289,7 @@ public final class StringSerializer extends Serializer<String> {
       assert STRING_VALUE_FIELD_IS_CHARS;
       final char[] chars = (char[]) Platform.getObject(value, STRING_VALUE_FIELD_OFFSET);
       if (compressString) {
-        if (isLatin(chars)) {
+        if (StringUtils.isLatin(chars)) {
           writeCharsLatin(buffer, chars, chars.length);
         } else {
           writeCharsUTF16(buffer, chars, chars.length);
@@ -298,32 +299,6 @@ public final class StringSerializer extends Serializer<String> {
         buffer.writePrimitiveArrayWithSize(chars, Platform.CHAR_ARRAY_OFFSET, numBytes);
       }
     }
-  }
-
-  public static boolean isLatin(char[] chars) {
-    int numChars = chars.length;
-    int vectorizedLen = numChars >> 2;
-    int vectorizedChars = vectorizedLen << 2;
-    int endOffset = Platform.CHAR_ARRAY_OFFSET + (vectorizedChars << 1);
-    boolean isLatin = true;
-    for (int offset = Platform.CHAR_ARRAY_OFFSET; offset < endOffset; offset += 8) {
-      // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
-      // See benchmark in CompressStringSuite.latinSuperWordCheck.
-      long multiChars = Platform.getLong(chars, offset);
-      if ((multiChars & MULTI_CHARS_NON_LATIN_MASK) != 0) {
-        isLatin = false;
-        break;
-      }
-    }
-    if (isLatin) {
-      for (int i = vectorizedChars; i < numChars; i++) {
-        if (chars[i] > 0xFF) {
-          isLatin = false;
-          break;
-        }
-      }
-    }
-    return isLatin;
   }
 
   // Invoked by fury JIT

--- a/java/fury-core/src/test/java/org/apache/fury/util/StringUtilsTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/util/StringUtilsTest.java
@@ -23,9 +23,11 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import org.apache.fury.FuryTestBase;
+import org.apache.fury.memory.Platform;
 import org.testng.annotations.Test;
 
-public class StringUtilsTest {
+public class StringUtilsTest extends FuryTestBase {
 
   @Test
   public void testEncodeHexString() {
@@ -86,5 +88,86 @@ public class StringUtilsTest {
     assertEquals(StringUtils.lowerCamelToLowerUnderscore("someLongVariable"), "some_long_variable");
     assertEquals(StringUtils.lowerCamelToLowerUnderscore("some123variable"), "some123variable");
     assertEquals(StringUtils.lowerCamelToLowerUnderscore("someVariable123"), "some_variable123");
+  }
+
+  @Test(dataProvider = "endian")
+  public void testVectorizedLatinCheckAlgorithm(boolean endian) {
+    // assertTrue(isLatin("Fury".toCharArray(), endian));
+    // assertTrue(isLatin(StringUtils.random(8 * 10).toCharArray(), endian));
+    // test unaligned
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "1").toCharArray(), endian));
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "12").toCharArray(), endian));
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "123").toCharArray(), endian));
+    assertFalse(isLatin("你好, Fury".toCharArray(), endian));
+    assertFalse(isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(), endian));
+    assertFalse(isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(), endian));
+  }
+
+  private boolean isLatin(char[] chars, boolean isLittle) {
+    boolean reverseBytes =
+        (Platform.IS_LITTLE_ENDIAN && !isLittle) || (!Platform.IS_LITTLE_ENDIAN && !isLittle);
+    if (reverseBytes) {
+      for (int i = 0; i < chars.length; i++) {
+        chars[i] = Character.reverseBytes(chars[i]);
+      }
+    }
+    long mask;
+    if (isLittle) {
+      // latin chars will be 0xXX,0x00;0xXX,0x00 in byte order;
+      // Using 0x00,0xff(0xff00) to clear latin bits.
+      mask = 0xff00ff00ff00ff00L;
+    } else {
+      // latin chars will be 0x00,0xXX;0x00,0xXX in byte order;
+      // Using 0x00,0xff(0x00ff) to clear latin bits.
+      mask = 0x00ff00ff00ff00ffL;
+    }
+    int numChars = chars.length;
+    int vectorizedLen = numChars >> 2;
+    int vectorizedChars = vectorizedLen << 2;
+    int endOffset = Platform.CHAR_ARRAY_OFFSET + (vectorizedChars << 1);
+    boolean isLatin = true;
+    for (int offset = Platform.CHAR_ARRAY_OFFSET; offset < endOffset; offset += 8) {
+      // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
+      long multiChars = Platform.getLong(chars, offset);
+      if ((multiChars & mask) != 0) {
+        isLatin = false;
+        break;
+      }
+    }
+    if (isLatin) {
+      for (int i = vectorizedChars; i < numChars; i++) {
+        char c = chars[i];
+        if (reverseBytes) {
+          c = Character.reverseBytes(c);
+        }
+        if (c > 0xFF) {
+          isLatin = false;
+          break;
+        }
+      }
+    }
+    return isLatin;
+  }
+
+  @Test
+  public void testLatinCheck() {
+    assertTrue(StringUtils.isLatin("Fury".toCharArray()));
+    assertTrue(StringUtils.isLatin(StringUtils.random(8 * 10).toCharArray()));
+    // test unaligned
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "1").toCharArray()));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "12").toCharArray()));
+    assertTrue(StringUtils.isLatin((StringUtils.random(8 * 10) + "123").toCharArray()));
+    assertFalse(StringUtils.isLatin("你好, Fury".toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(11) + "你").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(10) + "你好").toCharArray()));
+    assertFalse(StringUtils.isLatin((StringUtils.random(9) + "性能好").toCharArray()));
+    assertFalse(StringUtils.isLatin("\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("a\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("ab\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("abc\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("abcd\u1234".toCharArray()));
+    assertFalse(StringUtils.isLatin("Javaone Keynote\u1234".toCharArray()));
   }
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR moves the isLatin method from StringSerializer to StringUtils class
<!-- Describe the purpose of this PR. -->


## Related issues

- #1703
<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
