### PR TITLE
build: publish jars for fury-scala

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -16,16 +16,33 @@
  * limitations under the License.
  */
 
-name := "fury-scala"
+val furyVersion = "0.6.0-SNAPSHOT"
 val scala213Version = "2.13.14"
+ThisBuild / apacheSonatypeProjectProfile := "fury"
+version := furyVersion
 scalaVersion := scala213Version
 crossScalaVersions := Seq(scala213Version, "3.3.3")
+
+lazy val root = Project(id = "fury-scala", base = file("."))
+  .settings(
+    name := "fury-scala",
+    apacheSonatypeLicenseFile := baseDirectory.value / ".." / "LICENSE",
+    apacheSonatypeNoticeFile := baseDirectory.value / ".." / "NOTICE",
+    apacheSonatypeDisclaimerFile := Some(baseDirectory.value.getParentFile / "DISCLAIMER"),
+    description := "Apache Fury(Incubating) is a blazingly fast multi-language serialization framework powered by JIT and zero-copy.",
+    homepage := Some(url("https://fury.apache.org/")),
+    startYear := Some(2024),
+    developers := List(
+      Developer(
+        "fury-contributors",
+        "Apache Fury(Incubating) Contributors",
+        "dev@fury.apache.org",
+        url("https://github.com/apache/fury/graphs/contributors"))))
 
 resolvers += Resolver.mavenLocal
 resolvers += Resolver.ApacheMavenSnapshotsRepo
 
-val furyVersion = "0.6.0-SNAPSHOT"
 libraryDependencies ++= Seq(
   "org.apache.fury" % "fury-core" % furyVersion,
-  "org.scalatest" %% "scalatest" % "3.2.19",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test,
 )

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -28,7 +28,7 @@ lazy val root = Project(id = "fury-scala", base = file("."))
     name := "fury-scala",
     apacheSonatypeLicenseFile := baseDirectory.value / ".." / "LICENSE",
     apacheSonatypeNoticeFile := baseDirectory.value / ".." / "NOTICE",
-    apacheSonatypeDisclaimerFile := Some(baseDirectory.value.getParentFile / "DISCLAIMER"),
+    apacheSonatypeDisclaimerFile := Some(baseDirectory.value / ".." / "DISCLAIMER"),
     description := "Apache Fury(Incubating) is a blazingly fast multi-language serialization framework powered by JIT and zero-copy.",
     homepage := Some(url("https://fury.apache.org/")),
     startYear := Some(2024),

--- a/scala/project/plugins.sbt
+++ b/scala/project/plugins.sbt
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.11")


### PR DESCRIPTION
This PR uses https://github.com/mdedetrich/sbt-apache-sonatype to support publishing fury-scala jars to Apache's Nexus repository.

`sbt +publishSigned`

requires that you set NEXUS_USER and NEXUS_PW environment variables to provide your Apache username and password.

I have used my PR code to publish some snapshots to https://repository.apache.org/content/groups/snapshots/org/apache/fury/ 
