### PR TITLE
feat(java): Add 'Expose' annotation to support "only de/serialize annotated fields"

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/annotation/Expose.java
+++ b/java/fury-core/src/main/java/org/apache/fury/annotation/Expose.java
@@ -27,4 +27,4 @@ import java.lang.annotation.Target;
 /** Only fields with this annotation are permitted for de/serialization. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface Exposed {}
+public @interface Expose {}

--- a/java/fury-core/src/main/java/org/apache/fury/annotation/Exposed.java
+++ b/java/fury-core/src/main/java/org/apache/fury/annotation/Exposed.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Only fields with this annotation are permitted for de/serialization. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Exposed {}

--- a/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.fury.annotation.Exposed;
 import org.apache.fury.annotation.Ignore;
 import org.apache.fury.annotation.Internal;
@@ -375,13 +374,13 @@ public class Descriptor {
       boolean haveExposed = false,haveIgnore = false;
       for (Field field : fields) {
         warmField(clz, field, compilationService);
-        if(field.isAnnotationPresent(Exposed.class)){
+        if (field.isAnnotationPresent(Exposed.class)) {
           haveExposed = true;
         }
-        if(field.isAnnotationPresent(Ignore.class)){
+        if (field.isAnnotationPresent(Ignore.class)) {
           haveIgnore = true;
         }
-        if(haveExposed && haveIgnore){
+        if (haveExposed && haveIgnore) {
           descriptorMap.clear();
           throw new RuntimeException("Fields of a Class are not allowed to have both the Ignore and Exposed annotations simultaneously.");
         }
@@ -391,12 +390,12 @@ public class Descriptor {
         // final and non-private field validation left to {@link isBean(clz)}
         if (!Modifier.isTransient(modifiers)
             && !Modifier.isStatic(modifiers)) {
-          if(haveExposed){
-            if(field.isAnnotationPresent(Exposed.class)){
+          if (haveExposed) {
+            if (field.isAnnotationPresent(Exposed.class)) {
               descriptorMap.put(field, new Descriptor(field, null));
             }
-          } else{
-            if(!field.isAnnotationPresent(Ignore.class)){
+          } else {
+            if (!field.isAnnotationPresent(Ignore.class)) {
               descriptorMap.put(field, new Descriptor(field, null));
             }
           }

--- a/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
@@ -372,13 +372,16 @@ public class Descriptor {
     }
     do {
       Field[] fields = clazz.getDeclaredFields();
-      boolean haveExposed = false;
+      boolean haveExposed = false,haveIgnore = false;
       for (Field field : fields) {
         warmField(clz, field, compilationService);
         if(field.isAnnotationPresent(Exposed.class)){
           haveExposed = true;
         }
-        if(haveExposed && field.isAnnotationPresent(Ignore.class)){
+        if(field.isAnnotationPresent(Ignore.class)){
+          haveIgnore = true;
+        }
+        if(haveExposed && haveIgnore){
           descriptorMap.clear();
           throw new RuntimeException("Fields of a Class are not allowed to have both the Ignore and Exposed annotations simultaneously.");
         }

--- a/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
@@ -371,7 +371,7 @@ public class Descriptor {
     }
     do {
       Field[] fields = clazz.getDeclaredFields();
-      boolean haveExposed = false,haveIgnore = false;
+      boolean haveExposed = false, haveIgnore = false;
       for (Field field : fields) {
         warmField(clz, field, compilationService);
         if (field.isAnnotationPresent(Exposed.class)) {
@@ -382,14 +382,14 @@ public class Descriptor {
         }
         if (haveExposed && haveIgnore) {
           descriptorMap.clear();
-          throw new RuntimeException("Fields of a Class are not allowed to have both the Ignore and Exposed annotations simultaneously.");
+          throw new RuntimeException(
+              "Fields of a Class are not allowed to have both the Ignore and Exposed annotations simultaneously.");
         }
       }
       for (Field field : fields) {
         int modifiers = field.getModifiers();
         // final and non-private field validation left to {@link isBean(clz)}
-        if (!Modifier.isTransient(modifiers)
-            && !Modifier.isStatic(modifiers)) {
+        if (!Modifier.isTransient(modifiers) && !Modifier.isStatic(modifiers)) {
           if (haveExposed) {
             if (field.isAnnotationPresent(Exposed.class)) {
               descriptorMap.put(field, new Descriptor(field, null));

--- a/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.fury.annotation.Exposed;
+import org.apache.fury.annotation.Expose;
 import org.apache.fury.annotation.Ignore;
 import org.apache.fury.annotation.Internal;
 import org.apache.fury.collection.Tuple2;
@@ -371,27 +371,26 @@ public class Descriptor {
     }
     do {
       Field[] fields = clazz.getDeclaredFields();
-      boolean haveExposed = false, haveIgnore = false;
+      boolean haveExpose = false, haveIgnore = false;
       for (Field field : fields) {
         warmField(clz, field, compilationService);
-        if (field.isAnnotationPresent(Exposed.class)) {
-          haveExposed = true;
+        if (field.isAnnotationPresent(Expose.class)) {
+          haveExpose = true;
         }
         if (field.isAnnotationPresent(Ignore.class)) {
           haveIgnore = true;
         }
-        if (haveExposed && haveIgnore) {
-          descriptorMap.clear();
+        if (haveExpose && haveIgnore) {
           throw new RuntimeException(
-              "Fields of a Class are not allowed to have both the Ignore and Exposed annotations simultaneously.");
+              "Fields of a Class are not allowed to have both the Ignore and Expose annotations simultaneously.");
         }
       }
       for (Field field : fields) {
         int modifiers = field.getModifiers();
         // final and non-private field validation left to {@link isBean(clz)}
         if (!Modifier.isTransient(modifiers) && !Modifier.isStatic(modifiers)) {
-          if (haveExposed) {
-            if (field.isAnnotationPresent(Exposed.class)) {
+          if (haveExpose) {
+            if (field.isAnnotationPresent(Expose.class)) {
               descriptorMap.put(field, new Descriptor(field, null));
             }
           } else {

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -52,6 +52,8 @@ import java.util.WeakHashMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import org.apache.fury.annotation.Exposed;
 import org.apache.fury.annotation.Ignore;
 import org.apache.fury.builder.Generated;
 import org.apache.fury.config.FuryBuilder;
@@ -435,6 +437,48 @@ public class FuryTest extends FuryTestBase {
     assertEquals(0, o.f1);
     assertEquals(0, o.f2);
     assertEquals(3, o.f3);
+  }
+
+    @Data
+  @AllArgsConstructor
+  private static class ExposedFields {
+    @Exposed
+    int f1;
+    @Exposed
+    long f2;
+    long f3;
+    @Exposed
+    ImmutableMap<String, Integer> map1;
+    ImmutableMap<String, Integer> map2;
+  }
+
+  @Test
+  public void testExposedFields() {
+    Fury fury = Fury.builder().requireClassRegistration(false).build();
+    ImmutableMap<String, Integer> map1 = ImmutableMap.of("1", 1);
+    ImmutableMap<String, Integer> map2 = ImmutableMap.of("2", 2);
+    ExposedFields o = serDe(fury, new ExposedFields(1, 2, 3, map1, map2));
+    assertEquals(1, o.f1);
+    assertEquals(2, o.f2);
+    assertEquals(0, o.f3);
+    assertEquals(o.map1, map1);
+    assertNull(o.map2);
+  }
+
+  @Data
+  @AllArgsConstructor
+  private static class ExposedFields2 {
+    @Exposed
+    int f1;
+    @Ignore
+    long f2;
+    long f3;
+  }
+
+  @Test
+  public void testExposedFields2() {
+    Fury fury = Fury.builder().requireClassRegistration(false).build();
+    assertThrows(RuntimeException.class, () -> serDe(fury, new ExposedFields2(1, 2, 3)));
   }
 
   @Test(timeOut = 60_000)

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -52,7 +52,7 @@ import java.util.WeakHashMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.fury.annotation.Exposed;
+import org.apache.fury.annotation.Expose;
 import org.apache.fury.annotation.Ignore;
 import org.apache.fury.builder.Generated;
 import org.apache.fury.config.FuryBuilder;
@@ -440,20 +440,20 @@ public class FuryTest extends FuryTestBase {
 
   @Data
   @AllArgsConstructor
-  private static class ExposedFields {
-    @Exposed int f1;
-    @Exposed long f2;
+  private static class ExposeFields {
+    @Expose int f1;
+    @Expose long f2;
     long f3;
-    @Exposed ImmutableMap<String, Integer> map1;
+    @Expose ImmutableMap<String, Integer> map1;
     ImmutableMap<String, Integer> map2;
   }
 
   @Test
-  public void testExposedFields() {
+  public void testExposeFields() {
     Fury fury = Fury.builder().requireClassRegistration(false).build();
     ImmutableMap<String, Integer> map1 = ImmutableMap.of("1", 1);
     ImmutableMap<String, Integer> map2 = ImmutableMap.of("2", 2);
-    ExposedFields o = serDe(fury, new ExposedFields(1, 2, 3, map1, map2));
+    ExposeFields o = serDe(fury, new ExposeFields(1, 2, 3, map1, map2));
     assertEquals(1, o.f1);
     assertEquals(2, o.f2);
     assertEquals(0, o.f3);
@@ -463,16 +463,16 @@ public class FuryTest extends FuryTestBase {
 
   @Data
   @AllArgsConstructor
-  private static class ExposedFields2 {
-    @Exposed int f1;
+  private static class ExposeFields2 {
+    @Expose int f1;
     @Ignore long f2;
     long f3;
   }
 
   @Test
-  public void testExposedFields2() {
+  public void testExposeFields2() {
     Fury fury = Fury.builder().requireClassRegistration(false).build();
-    assertThrows(RuntimeException.class, () -> serDe(fury, new ExposedFields2(1, 2, 3)));
+    assertThrows(RuntimeException.class, () -> serDe(fury, new ExposeFields2(1, 2, 3)));
   }
 
   @Test(timeOut = 60_000)

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -439,7 +439,7 @@ public class FuryTest extends FuryTestBase {
     assertEquals(3, o.f3);
   }
 
-    @Data
+  @Data
   @AllArgsConstructor
   private static class ExposedFields {
     @Exposed

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -52,7 +52,6 @@ import java.util.WeakHashMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import org.apache.fury.annotation.Exposed;
 import org.apache.fury.annotation.Ignore;
 import org.apache.fury.builder.Generated;
@@ -442,13 +441,10 @@ public class FuryTest extends FuryTestBase {
   @Data
   @AllArgsConstructor
   private static class ExposedFields {
-    @Exposed
-    int f1;
-    @Exposed
-    long f2;
+    @Exposed int f1;
+    @Exposed long f2;
     long f3;
-    @Exposed
-    ImmutableMap<String, Integer> map1;
+    @Exposed ImmutableMap<String, Integer> map1;
     ImmutableMap<String, Integer> map2;
   }
 
@@ -468,10 +464,8 @@ public class FuryTest extends FuryTestBase {
   @Data
   @AllArgsConstructor
   private static class ExposedFields2 {
-    @Exposed
-    int f1;
-    @Ignore
-    long f2;
+    @Exposed int f1;
+    @Ignore long f2;
     long f3;
   }
 


### PR DESCRIPTION
## What does this PR do?
Add `Expose` annotation to support "only de/serialize annotated fields"

## Related issues
#1735 

## Does this PR introduce any user-facing change?
- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
N/A