### PR TITLE
fix(java): fix big buffer streaming MetaShared read offset

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -345,7 +345,7 @@ public final class Fury implements BaseFury {
       writeData(buffer, classInfo, obj);
     }
     if (shareMeta) {
-      buffer.putInt32(startOffset, buffer.writerIndex());
+      buffer.putInt32(startOffset, buffer.writerIndex() - startOffset - 4);
       classResolver.writeClassDefs(buffer);
     }
   }
@@ -1064,7 +1064,7 @@ public final class Fury implements BaseFury {
           ClassInfo classInfo = classResolver.getOrUpdateClassInfo(obj.getClass());
           writeData(buffer, classInfo, obj);
         }
-        buffer.putInt32(startOffset, buffer.writerIndex());
+        buffer.putInt32(startOffset, buffer.writerIndex() - startOffset - 4);
         classResolver.writeClassDefs(buffer);
       } else {
         if (!refResolver.writeRefOrNull(buffer, obj)) {
@@ -1421,9 +1421,9 @@ public final class Fury implements BaseFury {
   }
 
   private void readClassDefs(MemoryBuffer buffer) {
-    int classDefOffset = buffer.readInt32();
+    int relativeClassDefOffset = buffer.readInt32();
     int readerIndex = buffer.readerIndex();
-    buffer.readerIndex(classDefOffset);
+    buffer.readerIndex(readerIndex + relativeClassDefOffset);
     classResolver.readClassDefs(buffer);
     classDefEndOffset = buffer.readerIndex();
     buffer.readerIndex(readerIndex);


### PR DESCRIPTION
## What does this PR do?

 fix big buffer streaming MetaShared read by using relative offset

## Related issues

Closes #1759 

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
