### PR TITLE
fix(java): Fix memory leak in `StructSerializer.xread()` caused by re-pushing instead of popping `GenericType`.

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
@@ -189,7 +189,7 @@ public class StructSerializer<T> extends Serializer<T> {
       Object fieldValue = fury.xreadRefByNullableSerializer(buffer, serializer);
       fieldAccessor.set(obj, fieldValue);
       if (hasGenerics) {
-        generics.pushGenericType(fieldGeneric);
+        generics.popGenericType();
       }
     }
     return obj;


### PR DESCRIPTION
## What does this PR do?

Fix memory leak in `StructSerializer.xread()` caused by re-pushing instead of popping `GenericType`.

## Related issues

None, probably.

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

N/A