### PR TITLE
feat(Rust): Support polymorphism

### DIFF
--- a/rust/fury-core/src/buffer.rs
+++ b/rust/fury-core/src/buffer.rs
@@ -256,6 +256,6 @@ impl<'bf> Reader<'bf> {
     }
 
     pub fn aligned<T>(&self) -> bool {
-        unsafe { (self.bf.as_ptr().add(self.cursor) as usize) % align_of::<T>() == 0 }
+        unsafe { (self.bf.as_ptr().add(self.cursor) as usize) % std::mem::align_of::<T>() == 0 }
     }
 }

--- a/rust/fury-core/src/buffer.rs
+++ b/rust/fury-core/src/buffer.rs
@@ -247,4 +247,15 @@ impl<'bf> Reader<'bf> {
         self.move_next(len);
         result
     }
+
+    pub fn reset_cursor_to_here(&self) -> impl FnOnce(&mut Self) {
+        let raw_cursor = self.cursor;
+        move |this: &mut Self| {
+            this.cursor = raw_cursor;
+        }
+    }
+
+    pub fn aligned<T>(&self) -> bool {
+        unsafe { (self.bf.as_ptr().add(self.cursor) as usize) % align_of::<T>() == 0 }
+    }
 }

--- a/rust/fury-core/src/error.rs
+++ b/rust/fury-core/src/error.rs
@@ -31,8 +31,8 @@ pub enum Error {
     #[error("BadRefFlag")]
     BadRefFlag,
 
-    #[error("Bad FieldType; expected: {expected:?}, actual: {actial:?}")]
-    FieldType { expected: i16, actial: i16 },
+    #[error("Bad FieldType; expected: {expected:?}, actual: {actual:?}")]
+    FieldType { expected: i16, actual: i16 },
 
     #[error("Bad timestamp; out-of-range number of milliseconds")]
     NaiveDateTime,
@@ -40,8 +40,8 @@ pub enum Error {
     #[error("Bad date; out-of-range")]
     NaiveDate,
 
-    #[error("Schema is not consistent; expected: {expected:?}, actual: {actial:?}")]
-    StructHash { expected: u32, actial: u32 },
+    #[error("Schema is not consistent; expected: {expected:?}, actual: {actual:?}")]
+    StructHash { expected: u32, actual: u32 },
 
     #[error("Bad Tag Type: {0}")]
     TagType(u8),

--- a/rust/fury-core/src/error.rs
+++ b/rust/fury-core/src/error.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::types::{FieldType, Language};
+use super::types::Language;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -32,7 +32,7 @@ pub enum Error {
     BadRefFlag,
 
     #[error("Bad FieldType; expected: {expected:?}, actual: {actial:?}")]
-    FieldType { expected: FieldType, actial: i16 },
+    FieldType { expected: i16, actial: i16 },
 
     #[error("Bad timestamp; out-of-range number of milliseconds")]
     NaiveDateTime,
@@ -75,4 +75,7 @@ pub enum Error {
 
     #[error("Invalid character value for LOWER_UPPER_DIGIT_SPECIAL decoding: {value:?}")]
     InvalidLowerUpperDigitSpecialValue { value: u8 },
+
+    #[error("Unregistered type when serializing or deserializing object of Any type: {value:?}")]
+    UnregisteredType { value: u32 },
 }

--- a/rust/fury-core/src/fury.rs
+++ b/rust/fury-core/src/fury.rs
@@ -17,19 +17,22 @@
 
 use crate::buffer::{Reader, Writer};
 use crate::error::Error;
+use crate::resolver::class_resolver::{ClassInfo, ClassResolver};
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
-use crate::serializer::Serializer;
+use crate::serializer::{Serializer, StructSerializer};
 use crate::types::{config_flags, Language, Mode, SIZE_OF_REF_AND_TYPE};
 
 pub struct Fury {
     mode: Mode,
+    class_resolver: ClassResolver,
 }
 
 impl Default for Fury {
     fn default() -> Self {
         Fury {
             mode: Mode::SchemaConsistent,
+            class_resolver: ClassResolver::default(),
         }
     }
 }
@@ -81,5 +84,14 @@ impl Fury {
             context.write_meta(meta_offset);
         }
         writer.dump()
+    }
+
+    pub fn get_class_resolver(&self) -> &ClassResolver {
+        &self.class_resolver
+    }
+
+    pub fn register<T: 'static + StructSerializer>(&mut self, id: u32) {
+        let class_info = ClassInfo::new::<T>(self, id);
+        self.class_resolver.register::<T>(class_info, id);
     }
 }

--- a/rust/fury-core/src/meta/type_meta.rs
+++ b/rust/fury-core/src/meta/type_meta.rs
@@ -19,20 +19,17 @@ use super::meta_string::MetaStringEncoder;
 use crate::buffer::{Reader, Writer};
 use crate::error::Error;
 use crate::meta::{Encoding, MetaStringDecoder};
-use crate::types::FieldType;
 
-//todo backward/forward compatibility
-#[allow(dead_code)]
 pub struct FieldInfo {
     field_name: String,
-    field_type: FieldType,
+    field_id: i16,
 }
 
 impl FieldInfo {
-    pub fn new(field_name: &str, field_type: FieldType) -> FieldInfo {
+    pub fn new(field_name: &str, field_type: i16) -> FieldInfo {
         FieldInfo {
             field_name: field_name.to_string(),
-            field_type,
+            field_id: field_type,
         }
     }
 
@@ -60,7 +57,7 @@ impl FieldInfo {
             .unwrap();
         FieldInfo {
             field_name,
-            field_type: FieldType::try_from(type_id).unwrap(),
+            field_id: type_id,
         }
     }
 
@@ -80,7 +77,7 @@ impl FieldInfo {
             header |= (size << 5) as u8;
             writer.u8(header);
         }
-        writer.i16(self.field_type as i16);
+        writer.i16(self.field_id);
         writer.bytes(encoded);
         Ok(writer.dump())
     }
@@ -97,6 +94,10 @@ impl TypeMetaLayer {
             type_id,
             field_info,
         }
+    }
+
+    pub fn get_type_id(&self) -> u32 {
+        self.type_id
     }
 
     pub fn get_field_info(&self) -> &Vec<FieldInfo> {
@@ -131,6 +132,10 @@ pub struct TypeMeta {
 impl TypeMeta {
     pub fn get_field_info(&self) -> &Vec<FieldInfo> {
         self.layers.first().unwrap().get_field_info()
+    }
+
+    pub fn get_type_id(&self) -> u32 {
+        self.layers.first().unwrap().get_type_id()
     }
 
     pub fn from_fields(type_id: u32, field_info: Vec<FieldInfo>) -> TypeMeta {

--- a/rust/fury-core/src/resolver/class_resolver.rs
+++ b/rust/fury-core/src/resolver/class_resolver.rs
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::context::{ReadContext, WriteContext};
+use crate::error::Error;
+use crate::fury::Fury;
+use crate::serializer::StructSerializer;
+use std::any::TypeId;
+use std::{any::Any, collections::HashMap};
+
+pub struct Harness {
+    serializer: fn(&dyn Any, &mut WriteContext),
+    deserializer: fn(&mut ReadContext) -> Result<Box<dyn Any>, Error>,
+}
+
+impl Harness {
+    pub fn new(
+        serializer: fn(&dyn Any, &mut WriteContext),
+        deserializer: fn(&mut ReadContext) -> Result<Box<dyn Any>, Error>,
+    ) -> Harness {
+        Harness {
+            serializer,
+            deserializer,
+        }
+    }
+
+    pub fn get_serializer(&self) -> fn(&dyn Any, &mut WriteContext) {
+        self.serializer
+    }
+
+    pub fn get_deserializer(&self) -> fn(&mut ReadContext) -> Result<Box<dyn Any>, Error> {
+        self.deserializer
+    }
+}
+
+pub struct ClassInfo {
+    type_def: Vec<u8>,
+    type_id: u32,
+}
+
+impl ClassInfo {
+    pub fn new<T: StructSerializer>(fury: &Fury, type_id: u32) -> ClassInfo {
+        ClassInfo {
+            type_def: T::type_def(fury),
+            type_id,
+        }
+    }
+
+    pub fn get_type_id(&self) -> u32 {
+        self.type_id
+    }
+
+    pub fn get_type_def(&self) -> &Vec<u8> {
+        &self.type_def
+    }
+}
+
+#[derive(Default)]
+pub struct ClassResolver {
+    serialize_map: HashMap<u32, Harness>,
+    type_id_map: HashMap<TypeId, u32>,
+    class_info_map: HashMap<TypeId, ClassInfo>,
+}
+
+impl ClassResolver {
+    pub fn get_class_info(&self, type_id: TypeId) -> &ClassInfo {
+        self.class_info_map.get(&type_id).unwrap()
+    }
+
+    pub fn register<T: StructSerializer>(&mut self, class_info: ClassInfo, id: u32) {
+        fn serializer<T2: 'static + StructSerializer>(this: &dyn Any, context: &mut WriteContext) {
+            let this = this.downcast_ref::<T2>();
+            match this {
+                Some(v) => {
+                    T2::serialize(v, context);
+                }
+                None => todo!(),
+            }
+        }
+
+        fn deserializer<T2: 'static + StructSerializer>(
+            context: &mut ReadContext,
+        ) -> Result<Box<dyn Any>, Error> {
+            match T2::deserialize(context) {
+                Ok(v) => Ok(Box::new(v)),
+                Err(e) => Err(e),
+            }
+        }
+        self.type_id_map.insert(TypeId::of::<T>(), id);
+        self.serialize_map
+            .insert(id, Harness::new(serializer::<T>, deserializer::<T>));
+        self.class_info_map.insert(TypeId::of::<T>(), class_info);
+    }
+
+    pub fn get_harness_by_type(&self, type_id: TypeId) -> Option<&Harness> {
+        self.get_harness(*self.type_id_map.get(&type_id).unwrap())
+    }
+
+    pub fn get_harness(&self, id: u32) -> Option<&Harness> {
+        self.serialize_map.get(&id)
+    }
+}

--- a/rust/fury-core/src/resolver/context.rs
+++ b/rust/fury-core/src/resolver/context.rs
@@ -41,8 +41,8 @@ impl<'se> WriteContext<'se> {
         }
     }
 
-    pub fn push_meta(&mut self, type_id: TypeId, type_def: &'static [u8]) -> usize {
-        self.meta_resolver.push(type_id, type_def)
+    pub fn push_meta(&mut self, type_id: TypeId) -> usize {
+        self.meta_resolver.push(type_id, self.fury)
     }
 
     pub fn write_meta(&mut self, offset: usize) {

--- a/rust/fury-core/src/resolver/meta_resolver.rs
+++ b/rust/fury-core/src/resolver/meta_resolver.rs
@@ -17,6 +17,7 @@
 
 use crate::buffer::{Reader, Writer};
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::meta::TypeMeta;
 use std::any::TypeId;
 use std::collections::HashMap;
@@ -44,17 +45,21 @@ impl MetaReaderResolver {
 
 #[derive(Default)]
 pub struct MetaWriterResolver<'a> {
-    type_defs: Vec<&'a [u8]>,
+    type_defs: Vec<&'a Vec<u8>>,
     type_id_index_map: HashMap<TypeId, usize>,
 }
 
 #[allow(dead_code)]
 impl<'a> MetaWriterResolver<'a> {
-    pub fn push<'b: 'a>(&mut self, type_id: TypeId, type_meta_bytes: &'b [u8]) -> usize {
+    pub fn push<'b: 'a>(&mut self, type_id: TypeId, fury: &'a Fury) -> usize {
         match self.type_id_index_map.get(&type_id) {
             None => {
                 let index = self.type_defs.len();
-                self.type_defs.push(type_meta_bytes);
+                self.type_defs.push(
+                    fury.get_class_resolver()
+                        .get_class_info(type_id)
+                        .get_type_def(),
+                );
                 self.type_id_index_map.insert(type_id, index);
                 index
             }

--- a/rust/fury-core/src/resolver/mod.rs
+++ b/rust/fury-core/src/resolver/mod.rs
@@ -15,5 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod class_resolver;
 pub mod context;
 pub mod meta_resolver;

--- a/rust/fury-core/src/serializer/any.rs
+++ b/rust/fury-core/src/serializer/any.rs
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::error::Error;
+use crate::fury::Fury;
+use crate::resolver::context::{ReadContext, WriteContext};
+use crate::serializer::Serializer;
+use crate::types::{FieldType, Mode, RefFlag};
+use std::any::Any;
+
+impl Serializer for Box<dyn Any> {
+    fn reserved_space() -> usize {
+        0
+    }
+
+    fn write(&self, _context: &mut WriteContext) {
+        panic!("unreachable")
+    }
+
+    fn read(_context: &mut ReadContext) -> Result<Self, Error> {
+        panic!("unreachable")
+    }
+
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::FuryTypeTag.into()
+    }
+
+    fn serialize(&self, context: &mut WriteContext) {
+        context
+            .get_fury()
+            .get_class_resolver()
+            .get_harness_by_type(self.as_ref().type_id())
+            .unwrap()
+            .get_serializer()(self.as_ref(), context);
+    }
+
+    fn deserialize(context: &mut ReadContext) -> Result<Self, Error> {
+        let reset_cursor = context.reader.reset_cursor_to_here();
+        // ref flag
+        let ref_flag = context.reader.i8();
+
+        if ref_flag == (RefFlag::NotNullValue as i8) || ref_flag == (RefFlag::RefValue as i8) {
+            if context.get_fury().get_mode().eq(&Mode::Compatible) {
+                let meta_index = context.reader.i16();
+                let type_id = context.meta_resolver.get(meta_index as usize).get_type_id();
+                reset_cursor(&mut context.reader);
+                context
+                    .get_fury()
+                    .get_class_resolver()
+                    .get_harness(type_id)
+                    .unwrap()
+                    .get_deserializer()(context)
+            } else {
+                let type_id = context.reader.i16();
+                reset_cursor(&mut context.reader);
+                context
+                    .get_fury()
+                    .get_class_resolver()
+                    .get_harness(type_id as u32)
+                    .unwrap()
+                    .get_deserializer()(context)
+            }
+        } else if ref_flag == (RefFlag::Null as i8) {
+            Err(Error::Null)
+        } else if ref_flag == (RefFlag::Ref as i8) {
+            reset_cursor(&mut context.reader);
+            Err(Error::Ref)
+        } else {
+            reset_cursor(&mut context.reader);
+            Err(Error::BadRefFlag)
+        }
+    }
+}

--- a/rust/fury-core/src/serializer/any.rs
+++ b/rust/fury-core/src/serializer/any.rs
@@ -35,7 +35,7 @@ impl Serializer for Box<dyn Any> {
         panic!("unreachable")
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::FuryTypeTag.into()
     }
 

--- a/rust/fury-core/src/serializer/bool.rs
+++ b/rust/fury-core/src/serializer/bool.rs
@@ -36,7 +36,7 @@ impl Serializer for bool {
         Ok(context.reader.u8() == 1)
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::BOOL.into()
     }
 }

--- a/rust/fury-core/src/serializer/bool.rs
+++ b/rust/fury-core/src/serializer/bool.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
@@ -35,7 +36,7 @@ impl Serializer for bool {
         Ok(context.reader.u8() == 1)
     }
 
-    fn ty() -> FieldType {
-        FieldType::BOOL
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::BOOL.into()
     }
 }

--- a/rust/fury-core/src/serializer/datetime.rs
+++ b/rust/fury-core/src/serializer/datetime.rs
@@ -43,7 +43,7 @@ impl Serializer for NaiveDateTime {
         mem::size_of::<u64>()
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::TIMESTAMP.into()
     }
 }
@@ -68,7 +68,7 @@ impl Serializer for NaiveDate {
         }
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::DATE.into()
     }
 }

--- a/rust/fury-core/src/serializer/datetime.rs
+++ b/rust/fury-core/src/serializer/datetime.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
@@ -42,8 +43,8 @@ impl Serializer for NaiveDateTime {
         mem::size_of::<u64>()
     }
 
-    fn ty() -> FieldType {
-        FieldType::TIMESTAMP
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::TIMESTAMP.into()
     }
 }
 
@@ -67,8 +68,8 @@ impl Serializer for NaiveDate {
         }
     }
 
-    fn ty() -> FieldType {
-        FieldType::DATE
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::DATE.into()
     }
 }
 

--- a/rust/fury-core/src/serializer/list.rs
+++ b/rust/fury-core/src/serializer/list.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
@@ -52,8 +53,8 @@ where
         mem::size_of::<u32>()
     }
 
-    fn ty() -> FieldType {
-        FieldType::ARRAY
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::ARRAY.into()
     }
 }
 

--- a/rust/fury-core/src/serializer/list.rs
+++ b/rust/fury-core/src/serializer/list.rs
@@ -53,7 +53,7 @@ where
         mem::size_of::<u32>()
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::ARRAY.into()
     }
 }

--- a/rust/fury-core/src/serializer/map.rs
+++ b/rust/fury-core/src/serializer/map.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
@@ -58,8 +59,8 @@ impl<T1: Serializer + Eq + std::hash::Hash, T2: Serializer> Serializer for HashM
         mem::size_of::<i32>()
     }
 
-    fn ty() -> FieldType {
-        FieldType::MAP
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::MAP.into()
     }
 }
 

--- a/rust/fury-core/src/serializer/map.rs
+++ b/rust/fury-core/src/serializer/map.rs
@@ -59,7 +59,7 @@ impl<T1: Serializer + Eq + std::hash::Hash, T2: Serializer> Serializer for HashM
         mem::size_of::<i32>()
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::MAP.into()
     }
 }

--- a/rust/fury-core/src/serializer/number.rs
+++ b/rust/fury-core/src/serializer/number.rs
@@ -16,16 +16,11 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
 use crate::types::{FieldType, FuryGeneralList};
-
-#[allow(dead_code)]
-fn to_u8_slice<T>(slice: &[T]) -> &[u8] {
-    let byte_len = std::mem::size_of_val(slice);
-    unsafe { std::slice::from_raw_parts(slice.as_ptr().cast::<u8>(), byte_len) }
-}
 
 macro_rules! impl_num_serializer {
     ($name: ident, $ty:tt, $field_type: expr) => {
@@ -42,8 +37,8 @@ macro_rules! impl_num_serializer {
                 std::mem::size_of::<$ty>()
             }
 
-            fn ty() -> FieldType {
-                $field_type
+            fn ty(_fury: &Fury) -> i16 {
+                ($field_type).into()
             }
         }
     };

--- a/rust/fury-core/src/serializer/number.rs
+++ b/rust/fury-core/src/serializer/number.rs
@@ -37,7 +37,7 @@ macro_rules! impl_num_serializer {
                 std::mem::size_of::<$ty>()
             }
 
-            fn ty(_fury: &Fury) -> i16 {
+            fn get_type_id(_fury: &Fury) -> i16 {
                 ($field_type).into()
             }
         }

--- a/rust/fury-core/src/serializer/option.rs
+++ b/rust/fury-core/src/serializer/option.rs
@@ -33,12 +33,12 @@ impl<T: Serializer> Serializer for Option<T> {
 
         if ref_flag == (RefFlag::NotNullValue as i8) || ref_flag == (RefFlag::RefValue as i8) {
             // type_id
-            let type_id = context.reader.i16();
-
-            if type_id != T::ty(context.get_fury()) {
+            let actual_type_id = context.reader.i16();
+            let expected_type_id = T::get_type_id(context.get_fury());
+            if actual_type_id != expected_type_id {
                 Err(Error::FieldType {
-                    expected: T::ty(context.get_fury()),
-                    actial: type_id,
+                    expected: expected_type_id,
+                    actual: actual_type_id,
                 })
             } else {
                 Ok(Some(T::read(context)?))
@@ -66,7 +66,7 @@ impl<T: Serializer> Serializer for Option<T> {
                 // ref flag
                 context.writer.i8(RefFlag::NotNullValue as i8);
                 // type
-                context.writer.i16(T::ty(context.get_fury()));
+                context.writer.i16(T::get_type_id(context.get_fury()));
 
                 v.write(context);
             }
@@ -80,8 +80,8 @@ impl<T: Serializer> Serializer for Option<T> {
         std::mem::size_of::<T>()
     }
 
-    fn ty(fury: &Fury) -> i16 {
-        T::ty(fury)
+    fn get_type_id(fury: &Fury) -> i16 {
+        T::get_type_id(fury)
     }
 }
 

--- a/rust/fury-core/src/serializer/option.rs
+++ b/rust/fury-core/src/serializer/option.rs
@@ -16,10 +16,11 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
-use crate::types::{FieldType, FuryGeneralList, RefFlag};
+use crate::types::{FuryGeneralList, RefFlag};
 
 impl<T: Serializer> Serializer for Option<T> {
     fn read(context: &mut ReadContext) -> Result<Self, Error> {
@@ -34,9 +35,9 @@ impl<T: Serializer> Serializer for Option<T> {
             // type_id
             let type_id = context.reader.i16();
 
-            if type_id != T::ty() as i16 {
+            if type_id != T::ty(context.get_fury()) {
                 Err(Error::FieldType {
-                    expected: T::ty(),
+                    expected: T::ty(context.get_fury()),
                     actial: type_id,
                 })
             } else {
@@ -65,7 +66,7 @@ impl<T: Serializer> Serializer for Option<T> {
                 // ref flag
                 context.writer.i8(RefFlag::NotNullValue as i8);
                 // type
-                context.writer.i16(T::ty() as i16);
+                context.writer.i16(T::ty(context.get_fury()));
 
                 v.write(context);
             }
@@ -79,8 +80,8 @@ impl<T: Serializer> Serializer for Option<T> {
         std::mem::size_of::<T>()
     }
 
-    fn ty() -> FieldType {
-        T::ty()
+    fn ty(fury: &Fury) -> i16 {
+        T::ty(fury)
     }
 }
 

--- a/rust/fury-core/src/serializer/primitive_list.rs
+++ b/rust/fury-core/src/serializer/primitive_list.rs
@@ -60,7 +60,7 @@ macro_rules! impl_primitive_vec {
                 mem::size_of::<i32>()
             }
 
-            fn ty(_fury: &Fury) -> i16 {
+            fn get_type_id(_fury: &Fury) -> i16 {
                 ($field_type).into()
             }
         }
@@ -77,7 +77,7 @@ impl Serializer for Vec<bool> {
         mem::size_of::<u8>()
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::FuryPrimitiveBoolArray.into()
     }
 

--- a/rust/fury-core/src/serializer/set.rs
+++ b/rust/fury-core/src/serializer/set.rs
@@ -54,7 +54,7 @@ impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
         mem::size_of::<i32>()
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::FurySet.into()
     }
 }

--- a/rust/fury-core/src/serializer/set.rs
+++ b/rust/fury-core/src/serializer/set.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
@@ -53,8 +54,8 @@ impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
         mem::size_of::<i32>()
     }
 
-    fn ty() -> FieldType {
-        FieldType::FurySet
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::FurySet.into()
     }
 }
 

--- a/rust/fury-core/src/serializer/string.rs
+++ b/rust/fury-core/src/serializer/string.rs
@@ -38,7 +38,7 @@ impl Serializer for String {
         Ok(context.reader.string(len as usize))
     }
 
-    fn ty(_fury: &Fury) -> i16 {
+    fn get_type_id(_fury: &Fury) -> i16 {
         FieldType::STRING.into()
     }
 }

--- a/rust/fury-core/src/serializer/string.rs
+++ b/rust/fury-core/src/serializer/string.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::Error;
+use crate::fury::Fury;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
@@ -37,8 +38,8 @@ impl Serializer for String {
         Ok(context.reader.string(len as usize))
     }
 
-    fn ty() -> FieldType {
-        FieldType::STRING
+    fn ty(_fury: &Fury) -> i16 {
+        FieldType::STRING.into()
     }
 }
 

--- a/rust/fury-core/src/types.rs
+++ b/rust/fury-core/src/types.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::error::Error;
-use num_enum::TryFromPrimitive;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::mem;
 
 #[allow(dead_code)]
@@ -38,7 +38,7 @@ pub enum RefFlag {
     RefValue = 0,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive, IntoPrimitive)]
 #[repr(i16)]
 pub enum FieldType {
     BOOL = 1,
@@ -124,8 +124,6 @@ pub fn compute_struct_hash(props: Vec<(&str, FieldType)>) -> u32 {
     hash
 }
 
-// todo: flag check
-#[allow(dead_code)]
 pub mod config_flags {
     pub const IS_NULL_FLAG: u8 = 1 << 0;
     pub const IS_LITTLE_ENDIAN_FLAG: u8 = 2;

--- a/rust/fury-derive/src/lib.rs
+++ b/rust/fury-derive/src/lib.rs
@@ -23,22 +23,10 @@ mod fury_row;
 mod object;
 mod util;
 
-#[proc_macro_derive(Fury, attributes(tag))]
+#[proc_macro_derive(Fury)]
 pub fn proc_macro_derive_fury_object(input: proc_macro::TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let tag = input
-        .attrs
-        .iter()
-        .find(|attr| attr.path().is_ident("tag"))
-        .expect("should have tag");
-    let expr: syn::ExprLit = tag.parse_args().expect("should tag contain string value");
-    let tag = match expr.lit {
-        syn::Lit::Str(s) => s.value(),
-        _ => {
-            panic!("tag should be string")
-        }
-    };
-    object::derive_serializer(&input, &tag)
+    object::derive_serializer(&input)
 }
 
 #[proc_macro_derive(FuryRow)]

--- a/rust/fury-derive/src/object/misc.rs
+++ b/rust/fury-derive/src/object/misc.rs
@@ -48,46 +48,31 @@ fn type_def(fields: &[&Field]) -> TokenStream {
         let ty = &field.ty;
         let name = format!("{}", field.ident.as_ref().expect("should be field name"));
         quote! {
-            fury_core::meta::FieldInfo::new(#name, <#ty as fury_core::serializer::Serializer>::ty())
+            fury_core::meta::FieldInfo::new(#name, <#ty as fury_core::serializer::Serializer>::ty(fury))
         }
     });
     quote! {
-        fn fury_type_def() -> &'static [u8] {
-            use std::sync::Once;
-            static mut type_definition: Vec<u8> = Vec::new();
-            static type_definition_once: Once = Once::new();
-            unsafe {
-                type_definition_once.call_once(|| {
-                    type_definition = fury_core::meta::TypeMeta::from_fields(
-                        0,
-                        vec![#(#field_infos),*]
-                    ).to_bytes().unwrap();
-                });
-                type_definition.as_slice()
-            }
+        fn type_def(fury: &fury_core::fury::Fury) -> Vec<u8> {
+            fury_core::meta::TypeMeta::from_fields(
+                0,
+                vec![#(#field_infos),*]
+            ).to_bytes().unwrap()
         }
     }
 }
 
-pub fn gen_in_struct_impl(fields: &[&Field], tag: &String) -> TokenStream {
-    let hash_token_stream = hash(fields);
+pub fn gen_in_struct_impl(fields: &[&Field]) -> TokenStream {
+    let _hash_token_stream = hash(fields);
     let type_def_token_stream = type_def(fields);
 
     quote! {
-        #hash_token_stream
-
         #type_def_token_stream
-
-        fn fury_tag() -> &'static str {
-            #tag
-        }
     }
 }
-
 pub fn gen() -> TokenStream {
     quote! {
-            fn ty() -> fury_core::types::FieldType {
-                fury_core::types::FieldType::FuryTypeTag
+            fn ty(fury: &fury_core::fury::Fury) -> i16 {
+                fury.get_class_resolver().get_class_info(std::any::TypeId::of::<Self>()).get_type_id() as i16
             }
     }
 }

--- a/rust/fury-derive/src/object/misc.rs
+++ b/rust/fury-derive/src/object/misc.rs
@@ -24,7 +24,7 @@ fn hash(fields: &[&Field]) -> TokenStream {
         let ty = &field.ty;
         let name = format!("{}", field.ident.as_ref().expect("should be field name"));
         quote! {
-            (#name, <#ty as fury_core::serializer::Serializer>::ty())
+            (#name, <#ty as fury_core::serializer::Serializer>::get_type_id())
         }
     });
 
@@ -48,7 +48,7 @@ fn type_def(fields: &[&Field]) -> TokenStream {
         let ty = &field.ty;
         let name = format!("{}", field.ident.as_ref().expect("should be field name"));
         quote! {
-            fury_core::meta::FieldInfo::new(#name, <#ty as fury_core::serializer::Serializer>::ty(fury))
+            fury_core::meta::FieldInfo::new(#name, <#ty as fury_core::serializer::Serializer>::get_type_id(fury))
         }
     });
     quote! {
@@ -71,7 +71,7 @@ pub fn gen_in_struct_impl(fields: &[&Field]) -> TokenStream {
 }
 pub fn gen() -> TokenStream {
     quote! {
-            fn ty(fury: &fury_core::fury::Fury) -> i16 {
+            fn get_type_id(fury: &fury_core::fury::Fury) -> i16 {
                 fury.get_class_resolver().get_class_info(std::any::TypeId::of::<Self>()).get_type_id() as i16
             }
     }

--- a/rust/fury-derive/src/object/serializer.rs
+++ b/rust/fury-derive/src/object/serializer.rs
@@ -20,7 +20,7 @@ use crate::util::sorted_fields;
 use proc_macro::TokenStream;
 use quote::quote;
 
-pub fn derive_serializer(ast: &syn::DeriveInput, tag: &String) -> TokenStream {
+pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let fields = match &ast.data {
         syn::Data::Struct(s) => sorted_fields(&s.fields),
@@ -30,12 +30,12 @@ pub fn derive_serializer(ast: &syn::DeriveInput, tag: &String) -> TokenStream {
     };
 
     let misc_token_stream = misc::gen();
-    let struct_impl_token_stream = misc::gen_in_struct_impl(&fields, tag);
-    let write_token_stream = write::gen(name, &fields);
-    let read_token_stream = read::gen(name, &fields);
+    let struct_impl_token_stream = misc::gen_in_struct_impl(&fields);
+    let write_token_stream = write::gen(&fields);
+    let read_token_stream = read::gen(&fields);
 
     let gen = quote! {
-        impl #name {
+        impl fury_core::serializer::StructSerializer for #name {
             #struct_impl_token_stream
         }
         impl fury_core::types::FuryGeneralList for #name {}

--- a/rust/tests/tests/test_complex_struct.rs
+++ b/rust/tests/tests/test_complex_struct.rs
@@ -45,7 +45,7 @@ fn any() {
     fury.register::<Person>(1000);
     let bin = fury.serialize(&person);
     let obj: Person = fury.deserialize(&bin).expect("");
-    assert_eq!(true, obj.f1.is::<Animal>())
+    assert!(obj.f1.is::<Animal>())
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?
1. Support polymorphism
Add a class resolver which is used for managing the relationship between type_id and serializer. The serializer is generated by a generic function which will be called by dynamic dispatch. When a struct uses `Box<dyn Any>` as a field type and does not specify the specific type, we will use the class resolver to load the handler by type_id. In this situation, there is some performance overhead due to hash lookup, but it greatly improves convenience.
Use as follow:
```Rust
#[test]
fn any() {
    #[derive(Fury, Debug)]
    struct Animal {
        f3: String,
    }

    #[derive(Fury, Debug)]
    struct Person {
        f1: Box<dyn Any>,
    }

    let person = Person {
        f1: Box::new(Animal {
            f3: String::from("hello"),
        }),
    };

    let mut fury = Fury::default();
    fury.register::<Animal>(999);
    fury.register::<Person>(1000);
    let bin = fury.serialize(&person);
    let obj: Person = fury.deserialize(&bin).expect("");
    assert_eq!(true, obj.f1.is::<Animal>())
}

```
2. Add a register  function for user to register Struct and id
3. Remove tag and hash which were generate by macro before and were removed in our protocol now.

## TODO
1. Internal types like String、Set and Map should be registered by fury by default and lookup by pattern match to avoid hash overhead.
2. More unit testcases.
3. Support `Box<dyn customTrait> `