### PR TITLE
feat(Rust): Support serialization and deserialization of trait objects

### DIFF
--- a/rust/fury-core/src/error.rs
+++ b/rust/fury-core/src/error.rs
@@ -78,4 +78,7 @@ pub enum Error {
 
     #[error("Unregistered type when serializing or deserializing object of Any type: {value:?}")]
     UnregisteredType { value: u32 },
+
+    #[error("Unregistered type when serializing or deserializing object of Any type: ")]
+    ConvertToTraitObjectError {  },
 }

--- a/rust/fury-core/src/fury.rs
+++ b/rust/fury-core/src/fury.rs
@@ -15,12 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use chrono::{NaiveDate, NaiveDateTime};
+
 use crate::buffer::{Reader, Writer};
 use crate::error::Error;
 use crate::resolver::class_resolver::{ClassInfo, ClassResolver};
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
-use crate::serializer::{Serializer, StructSerializer};
+use crate::serializer::Serializer;
 use crate::types::{config_flags, Language, Mode, SIZE_OF_REF_AND_TYPE};
 
 pub struct Fury {
@@ -30,14 +32,36 @@ pub struct Fury {
 
 impl Default for Fury {
     fn default() -> Self {
-        Fury {
+        let mut fury = Fury {
             mode: Mode::SchemaConsistent,
             class_resolver: ClassResolver::default(),
-        }
+        };
+        fury.register_internal_type::<u8>();
+        fury.register_internal_type::<i8>();
+        fury.register_internal_type::<u16>();
+        fury.register_internal_type::<i16>();
+        fury.register_internal_type::<u32>();
+        fury.register_internal_type::<i32>();
+        fury.register_internal_type::<u64>();
+        fury.register_internal_type::<i64>();
+        fury.register_internal_type::<f32>();
+        fury.register_internal_type::<f64>();
+        fury.register_internal_type::<String>();
+        fury.register_internal_type::<bool>();
+        fury.register_internal_type::<NaiveDate>();
+        fury.register_internal_type::<NaiveDateTime>();
+        // todo generic type
+        fury
     }
 }
 
+
 impl Fury {
+
+    fn register_internal_type<T: Serializer>(&mut self) {
+        self.register::<i32>(T::get_type_id(self) as u32);
+    }
+
     pub fn mode(mut self, mode: Mode) -> Self {
         self.mode = mode;
         self
@@ -90,8 +114,11 @@ impl Fury {
         &self.class_resolver
     }
 
-    pub fn register<T: 'static + StructSerializer>(&mut self, id: u32) {
-        let class_info = ClassInfo::new::<T>(self, id);
-        self.class_resolver.register::<T>(class_info, id);
+    pub fn register<T: 'static + Serializer>(&mut self, id: u32)
+    {
+        self.class_resolver.register::<T>( ClassInfo::new::<T>(
+            self,
+            id
+        ), id);
     }
 }

--- a/rust/fury-core/src/lib.rs
+++ b/rust/fury-core/src/lib.rs
@@ -24,3 +24,4 @@ pub mod row;
 pub mod serializer;
 pub mod types;
 pub mod util;
+pub mod raw;

--- a/rust/fury-core/src/raw/maybe_trait_object.rs
+++ b/rust/fury-core/src/raw/maybe_trait_object.rs
@@ -1,0 +1,31 @@
+use mem::transmute;
+use std::any::TypeId;
+use std::mem;
+use crate::error::Error;
+
+pub struct MaybeTraitObject {
+    ptr: *const u8,
+    type_id: TypeId
+}
+
+impl MaybeTraitObject {
+    pub fn new<T: 'static>(value: T) -> MaybeTraitObject {
+        let ptr = unsafe { transmute::<Box<T>, *const u8>(Box::new(value)) };
+        let type_id = TypeId::of::<T>();
+        MaybeTraitObject {
+            ptr,
+            type_id
+        }
+    }
+
+    pub fn to_trait_object<T: 'static>(self) -> Result<T, Error> {
+        if self.type_id == TypeId::of::<T>() {
+            Ok(unsafe {
+                *(transmute::<*const u8, Box<T>>(self.ptr))
+            })
+        } else {
+            Err(Error::ConvertToTraitObjectError {})
+        }
+    }
+}
+

--- a/rust/fury-core/src/raw/mod.rs
+++ b/rust/fury-core/src/raw/mod.rs
@@ -1,0 +1,3 @@
+
+
+pub mod maybe_trait_object;

--- a/rust/fury-core/src/resolver/class_resolver.rs
+++ b/rust/fury-core/src/resolver/class_resolver.rs
@@ -18,99 +18,86 @@
 use super::context::{ReadContext, WriteContext};
 use crate::error::Error;
 use crate::fury::Fury;
-use crate::serializer::StructSerializer;
+use crate::serializer::Serializer;
 use std::any::TypeId;
 use std::{any::Any, collections::HashMap};
+use crate::raw::maybe_trait_object::MaybeTraitObject;
 
-pub struct Harness {
-    serializer: fn(&dyn Any, &mut WriteContext),
-    deserializer: fn(&mut ReadContext) -> Result<Box<dyn Any>, Error>,
-}
 
-impl Harness {
-    pub fn new(
-        serializer: fn(&dyn Any, &mut WriteContext),
-        deserializer: fn(&mut ReadContext) -> Result<Box<dyn Any>, Error>,
-    ) -> Harness {
-        Harness {
-            serializer,
-            deserializer,
-        }
-    }
-
-    pub fn get_serializer(&self) -> fn(&dyn Any, &mut WriteContext) {
-        self.serializer
-    }
-
-    pub fn get_deserializer(&self) -> fn(&mut ReadContext) -> Result<Box<dyn Any>, Error> {
-        self.deserializer
-    }
-}
+pub type TraitObjectDeserializer = fn(&mut ReadContext) -> Result<MaybeTraitObject, Error>;
 
 pub struct ClassInfo {
     type_def: Vec<u8>,
-    type_id: u32,
+    fury_type_id: u32,
+    rust_type_id: TypeId,
+    trait_object_serializer: fn(&dyn Any, &mut WriteContext),
+    trait_object_deserializer: HashMap<TypeId, TraitObjectDeserializer>
 }
 
+
+fn serialize<T: 'static + Serializer>(this: &dyn Any, context: &mut WriteContext) {
+    let this = this.downcast_ref::<T>().unwrap();
+    T::serialize(this, context)
+}
+
+
+
 impl ClassInfo {
-    pub fn new<T: StructSerializer>(fury: &Fury, type_id: u32) -> ClassInfo {
+    pub fn new<T: Serializer>(
+        fury: &Fury,
+        type_id: u32
+    ) -> ClassInfo {
         ClassInfo {
             type_def: T::type_def(fury),
-            type_id,
+            fury_type_id: type_id,
+            rust_type_id: TypeId::of::<T>(),
+            trait_object_serializer: serialize::<T>,
+            trait_object_deserializer: T::get_trait_object_deserializer()
         }
     }
 
-    pub fn get_type_id(&self) -> u32 {
-        self.type_id
+    pub fn get_rust_type_id(&self) -> TypeId {
+        self.rust_type_id
+    }
+
+    pub fn get_fury_type_id(&self) -> u32 {
+        self.fury_type_id
     }
 
     pub fn get_type_def(&self) -> &Vec<u8> {
         &self.type_def
     }
+
+    pub fn get_serializer(&self) -> fn(&dyn Any, &mut WriteContext) {
+        self.trait_object_serializer
+    }
+
+    pub fn get_trait_object_deserializer<T: 'static>(&self) -> Option<&TraitObjectDeserializer> {
+        let type_id = TypeId::of::<T>();
+        self.trait_object_deserializer.get(&type_id)
+    }
 }
 
 #[derive(Default)]
 pub struct ClassResolver {
-    serialize_map: HashMap<u32, Harness>,
-    type_id_map: HashMap<TypeId, u32>,
+    fury_type_id_map: HashMap<u32, TypeId>,
     class_info_map: HashMap<TypeId, ClassInfo>,
 }
 
+
 impl ClassResolver {
-    pub fn get_class_info(&self, type_id: TypeId) -> &ClassInfo {
+    pub fn get_class_info_by_rust_type(&self, type_id: TypeId) -> &ClassInfo {
         self.class_info_map.get(&type_id).unwrap()
     }
 
-    pub fn register<T: StructSerializer>(&mut self, class_info: ClassInfo, id: u32) {
-        fn serializer<T2: 'static + StructSerializer>(this: &dyn Any, context: &mut WriteContext) {
-            let this = this.downcast_ref::<T2>();
-            match this {
-                Some(v) => {
-                    T2::serialize(v, context);
-                }
-                None => todo!(),
-            }
-        }
-
-        fn deserializer<T2: 'static + StructSerializer>(
-            context: &mut ReadContext,
-        ) -> Result<Box<dyn Any>, Error> {
-            match T2::deserialize(context) {
-                Ok(v) => Ok(Box::new(v)),
-                Err(e) => Err(e),
-            }
-        }
-        self.type_id_map.insert(TypeId::of::<T>(), id);
-        self.serialize_map
-            .insert(id, Harness::new(serializer::<T>, deserializer::<T>));
-        self.class_info_map.insert(TypeId::of::<T>(), class_info);
+    pub fn get_class_info_by_fury_type(&self, type_id: u32) -> &ClassInfo {
+        let type_id = self.fury_type_id_map.get(&type_id).unwrap();
+        self.class_info_map.get(type_id).unwrap()
     }
 
-    pub fn get_harness_by_type(&self, type_id: TypeId) -> Option<&Harness> {
-        self.get_harness(*self.type_id_map.get(&type_id).unwrap())
-    }
-
-    pub fn get_harness(&self, id: u32) -> Option<&Harness> {
-        self.serialize_map.get(&id)
+    pub fn register<T: Serializer>(&mut self, class_info: ClassInfo, id: u32) {
+        let type_id = TypeId::of::<T>();
+        self.fury_type_id_map.insert(id, type_id);
+        self.class_info_map.insert(type_id, class_info);
     }
 }

--- a/rust/fury-core/src/resolver/meta_resolver.rs
+++ b/rust/fury-core/src/resolver/meta_resolver.rs
@@ -57,7 +57,7 @@ impl<'a> MetaWriterResolver<'a> {
                 let index = self.type_defs.len();
                 self.type_defs.push(
                     fury.get_class_resolver()
-                        .get_class_info(type_id)
+                        .get_class_info_by_rust_type(type_id)
                         .get_type_def(),
                 );
                 self.type_id_index_map.insert(type_id, index);

--- a/rust/fury-core/src/serializer/any.rs
+++ b/rust/fury-core/src/serializer/any.rs
@@ -1,26 +1,10 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-use crate::error::Error;
-use crate::fury::Fury;
-use crate::resolver::context::{ReadContext, WriteContext};
-use crate::serializer::Serializer;
-use crate::types::{FieldType, Mode, RefFlag};
 use std::any::Any;
+
+use crate::{error::Error, fury::Fury, resolver::context::{ReadContext, WriteContext}, types::FieldType};
+use super::{polymorph, Serializer};
+
+
+
 
 impl Serializer for Box<dyn Any> {
     fn reserved_space() -> usize {
@@ -40,48 +24,10 @@ impl Serializer for Box<dyn Any> {
     }
 
     fn serialize(&self, context: &mut WriteContext) {
-        context
-            .get_fury()
-            .get_class_resolver()
-            .get_harness_by_type(self.as_ref().type_id())
-            .unwrap()
-            .get_serializer()(self.as_ref(), context);
+        polymorph::serialize(self.as_ref(), self.as_ref().type_id(), context);
     }
 
     fn deserialize(context: &mut ReadContext) -> Result<Self, Error> {
-        let reset_cursor = context.reader.reset_cursor_to_here();
-        // ref flag
-        let ref_flag = context.reader.i8();
-
-        if ref_flag == (RefFlag::NotNullValue as i8) || ref_flag == (RefFlag::RefValue as i8) {
-            if context.get_fury().get_mode().eq(&Mode::Compatible) {
-                let meta_index = context.reader.i16();
-                let type_id = context.meta_resolver.get(meta_index as usize).get_type_id();
-                reset_cursor(&mut context.reader);
-                context
-                    .get_fury()
-                    .get_class_resolver()
-                    .get_harness(type_id)
-                    .unwrap()
-                    .get_deserializer()(context)
-            } else {
-                let type_id = context.reader.i16();
-                reset_cursor(&mut context.reader);
-                context
-                    .get_fury()
-                    .get_class_resolver()
-                    .get_harness(type_id as u32)
-                    .unwrap()
-                    .get_deserializer()(context)
-            }
-        } else if ref_flag == (RefFlag::Null as i8) {
-            Err(Error::Null)
-        } else if ref_flag == (RefFlag::Ref as i8) {
-            reset_cursor(&mut context.reader);
-            Err(Error::Ref)
-        } else {
-            reset_cursor(&mut context.reader);
-            Err(Error::BadRefFlag)
-        }
+        polymorph::deserialize::<Self>(context)
     }
 }

--- a/rust/fury-core/src/serializer/list.rs
+++ b/rust/fury-core/src/serializer/list.rs
@@ -23,7 +23,7 @@ use crate::serializer::Serializer;
 use crate::types::{FieldType, FuryGeneralList, SIZE_OF_REF_AND_TYPE};
 use std::mem;
 
-impl<T> Serializer for Vec<T>
+impl<T: 'static> Serializer for Vec<T>
 where
     T: Serializer + FuryGeneralList,
 {

--- a/rust/fury-core/src/serializer/map.rs
+++ b/rust/fury-core/src/serializer/map.rs
@@ -24,7 +24,7 @@ use crate::types::{FieldType, FuryGeneralList, SIZE_OF_REF_AND_TYPE};
 use std::collections::HashMap;
 use std::mem;
 
-impl<T1: Serializer + Eq + std::hash::Hash, T2: Serializer> Serializer for HashMap<T1, T2> {
+impl<T1: Serializer + Eq + std::hash::Hash + 'static, T2: Serializer + 'static> Serializer for HashMap<T1, T2> {
     fn write(&self, context: &mut WriteContext) {
         // length
         context.writer.var_int32(self.len() as i32);

--- a/rust/fury-core/src/serializer/option.rs
+++ b/rust/fury-core/src/serializer/option.rs
@@ -22,7 +22,7 @@ use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
 use crate::types::{FuryGeneralList, RefFlag};
 
-impl<T: Serializer> Serializer for Option<T> {
+impl<T: Serializer + 'static> Serializer for Option<T> {
     fn read(context: &mut ReadContext) -> Result<Self, Error> {
         Ok(Some(T::read(context)?))
     }

--- a/rust/fury-core/src/serializer/polymorph.rs
+++ b/rust/fury-core/src/serializer/polymorph.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::error::Error;
+use crate::raw::maybe_trait_object::MaybeTraitObject;
+use crate::resolver::context::{ReadContext, WriteContext};
+use crate::types::{Mode, RefFlag};
+use std::any::{Any, TypeId};
+
+use super::Serializer;
+
+
+pub fn as_any_trait_object<T: Serializer + Any + 'static>(context: &mut ReadContext) -> Result<MaybeTraitObject, Error> {
+    match T::deserialize(context) {
+        Ok(v) => {
+            Ok(MaybeTraitObject::new(
+                Box::new(v) as Box<dyn Any>,
+            ))
+        },
+        Err(e) => Err(e),
+    }
+
+}
+
+pub fn serialize(value: &dyn Any, type_id: TypeId, context: &mut WriteContext) {
+    context
+        .get_fury()
+        .get_class_resolver()
+        .get_class_info_by_rust_type(type_id)
+        .get_serializer()
+        (value, context);
+}
+
+pub fn deserialize<T: 'static>(context: &mut ReadContext) -> Result<T, Error> {
+    let reset_cursor = context.reader.reset_cursor_to_here();
+    // ref flag
+    let ref_flag = context.reader.i8();
+
+    if ref_flag == (RefFlag::NotNullValue as i8) || ref_flag == (RefFlag::RefValue as i8) {
+        let type_id = if context.get_fury().get_mode().eq(&Mode::Compatible) {
+            context.meta_resolver.get(context.reader.i16() as usize).get_type_id()
+        } else {
+            context.reader.i16() as u32
+        };
+        reset_cursor(&mut context.reader);
+        let v = context
+            .get_fury()
+            .get_class_resolver()
+            .get_class_info_by_fury_type(type_id)
+            .get_trait_object_deserializer::<T>()
+            .unwrap()(context)?;
+        Ok(v.to_trait_object::<T>()?)
+    } else if ref_flag == (RefFlag::Null as i8) {
+        Err(Error::Null)
+    } else if ref_flag == (RefFlag::Ref as i8) {
+        reset_cursor(&mut context.reader);
+        Err(Error::Ref)
+    } else {
+        reset_cursor(&mut context.reader);
+        Err(Error::BadRefFlag)
+    }
+}

--- a/rust/fury-core/src/serializer/set.rs
+++ b/rust/fury-core/src/serializer/set.rs
@@ -24,7 +24,7 @@ use crate::types::{FieldType, FuryGeneralList, SIZE_OF_REF_AND_TYPE};
 use std::collections::HashSet;
 use std::mem;
 
-impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
+impl<T: Serializer + Eq + std::hash::Hash + 'static> Serializer for HashSet<T> {
     fn write(&self, context: &mut WriteContext) {
         // length
         context.writer.i32(self.len() as i32);

--- a/rust/fury-derive/src/object/misc.rs
+++ b/rust/fury-derive/src/object/misc.rs
@@ -72,7 +72,7 @@ pub fn gen_in_struct_impl(fields: &[&Field]) -> TokenStream {
 pub fn gen() -> TokenStream {
     quote! {
             fn get_type_id(fury: &fury_core::fury::Fury) -> i16 {
-                fury.get_class_resolver().get_class_info(std::any::TypeId::of::<Self>()).get_type_id() as i16
+                fury.get_class_resolver().get_class_info_by_rust_type(std::any::TypeId::of::<Self>()).get_fury_type_id() as i16
             }
     }
 }

--- a/rust/fury-derive/src/object/mod.rs
+++ b/rust/fury-derive/src/object/mod.rs
@@ -19,5 +19,5 @@ mod misc;
 mod read;
 mod serializer;
 mod write;
-
+mod polymorphic;
 pub use serializer::derive_serializer;

--- a/rust/fury-derive/src/object/polymorphic.rs
+++ b/rust/fury-derive/src/object/polymorphic.rs
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Attribute, Ident};
+
+
+fn parse_attributes(attrs: &[Attribute]) -> Vec<String> {
+    let tag = attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("polymorphic_traits"));
+    
+    if tag.is_none() {
+        return vec![];
+    }
+    
+    let expr: syn::ExprLit = tag.unwrap().parse_args().expect("should tag contain string value");
+    match expr.lit {
+        syn::Lit::Str(s) => {
+            let v: Vec<String> = s.value().split(",").map(|x| { x.to_string() }).collect();
+            v
+        },
+        _ => {
+            panic!("tag should be string")
+        }
+    }
+}
+
+pub fn gen(name: &Ident, attrs: &[Attribute]) -> TokenStream {
+    let traits = parse_attributes(attrs);
+    let stream = traits.iter().map(|x| {
+        let x: proc_macro2::Ident = syn::Ident::new(&x.to_string(), name.span());
+        let name: proc_macro2::Ident = syn::Ident::new(&format!("deserializer_trait_object_{}", x).to_lowercase(), name.span());
+        quote! {
+            fn #name<T: fury_core::serializer::Serializer + #x + 'static>(context: &mut fury_core::resolver::context::ReadContext) -> Result<fury_core::raw::maybe_trait_object::MaybeTraitObject, fury_core::error::Error> {
+                match T::deserialize(context) {
+                    Ok(v) => {
+                        Ok(fury_core::raw::maybe_trait_object::MaybeTraitObject::new(
+                            Box::new(v) as Box<dyn #x>,
+                        ))
+                    },
+                    Err(e) => Err(e),
+                }
+    
+            }
+            ret.insert(TypeId::of::<Box<dyn #x>>(), #name::<Self>);
+        }
+    });
+
+
+    quote! {
+        fn get_trait_object_deserializer() -> std::collections::hash_map::HashMap<TypeId, fn(context: &mut fury_core::resolver::context::ReadContext) -> Result<fury_core::raw::maybe_trait_object::MaybeTraitObject, fury_core::error::Error>> {
+            let mut ret: std::collections::hash_map::HashMap<TypeId, fn(context: &mut fury_core::resolver::context::ReadContext) -> Result<fury_core::raw::maybe_trait_object::MaybeTraitObject, fury_core::error::Error>> = std::collections::hash_map::HashMap::new();
+            ret.insert(TypeId::of::<Box<dyn Any>>(), fury_core::serializer::polymorph::as_any_trait_object::<Self>);
+            #(#stream)*
+            ret
+        }
+    }
+}

--- a/rust/tests/tests/test_complex_struct.rs
+++ b/rust/tests/tests/test_complex_struct.rs
@@ -19,34 +19,9 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime};
 use fury_core::fury::Fury;
 use fury_core::types::Mode;
 use fury_derive::Fury;
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
 
-#[test]
-fn any() {
-    #[derive(Fury, Debug)]
-    struct Animal {
-        f3: String,
-    }
-
-    #[derive(Fury, Debug)]
-    struct Person {
-        f1: Box<dyn Any>,
-    }
-
-    let person = Person {
-        f1: Box::new(Animal {
-            f3: String::from("hello"),
-        }),
-    };
-
-    let mut fury = Fury::default();
-    fury.register::<Animal>(999);
-    fury.register::<Person>(1000);
-    let bin = fury.serialize(&person);
-    let obj: Person = fury.deserialize(&bin).expect("");
-    assert!(obj.f1.is::<Animal>())
-}
 
 #[test]
 fn complex_struct() {

--- a/rust/tests/tests/test_custom_trait.rs
+++ b/rust/tests/tests/test_custom_trait.rs
@@ -1,0 +1,67 @@
+use std::any::{Any, TypeId};
+use fury_core::error::Error;
+use fury_core::fury::Fury;
+use fury_derive::{impl_polymorph, Fury};
+
+#[impl_polymorph]
+trait Animal {
+    fn get_name(&self) -> String;
+}
+
+#[derive(Fury, Debug)]
+#[polymorphic_traits("Animal")]
+struct Dog {
+    name: String
+}
+
+impl Animal for Dog {
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+
+#[test]
+fn test_custom_trait_object_work() {
+    let mut fury = Fury::default();
+
+    #[derive(Fury)]
+    struct Person {
+        z: Box<dyn Animal>
+    }
+
+    let p = Person {
+        z: Box::new(Dog {
+            name: String::from("puppy")
+        })
+    };
+    fury.register::<Person>(501);
+    fury.register::<Dog>(500);
+    let bin = fury.serialize(&p);
+    let obj: Person = fury.deserialize(&bin).unwrap();
+    assert_eq!(obj.z.get_name(), "puppy");
+}
+
+
+
+#[test]
+fn test_any_trait_object_work() {
+    let mut fury = Fury::default();
+
+    #[derive(Fury)]
+    struct Person {
+        pet: Box<dyn Any>
+    }
+
+    let p = Person {
+        pet: Box::new(Dog {
+            name: String::from("puppy")
+        })
+    };
+    fury.register::<Person>(501);
+    fury.register::<Dog>(500);
+    let bin = fury.serialize(&p);
+    let obj: Person = fury.deserialize(&bin).unwrap();
+    let pet = obj.pet.downcast_ref::<Dog>().unwrap();
+    assert_eq!(pet.get_name(), "puppy");
+}


### PR DESCRIPTION
## What does this PR do?
### Support serialization and deserialization of trait objects
The relationship between a trait object and a concrete type is generated by a macro and stored in a Fury instance. We can access the serializer and deserializer using the  `Fury type ID`  and  `Rust type ID`.

Use as follows
```Rust
    #[impl_polymorph]
    trait Animal {
        fn get_name(&self) -> String;
    }

    #[derive(Fury, Debug)]
    #[polymorphic_traits("Animal")]
    struct Dog {
        name: String
    }

    impl Animal for Dog {
        fn get_name(&self) -> String {
            self.name.clone()
        }
    }

    #[derive(Fury)]
    struct Person {
        pet: Box<dyn Animal>
    }

    let p = Person {
        pet: Box::new(Dog {
            name: String::from("puppy")
        })
    };
    let mut fury = Fury::default();

    fury.register::<Person>(501);
    fury.register::<Dog>(500);
    let bin = fury.serialize(&p);
    let obj: Person = fury.deserialize(&bin).unwrap();
    assert_eq!(obj.pet.get_name(), "puppy");
```
We should add `impl_polymorph` for trait  which is use for serializing `Box<dyn xxxx>`  and `polymorphic_traits` for struct which is use for generate code to cast upcast concete type to trait object. Note that rust not support upcast trait yet(https://github.com/rust-lang/rust/issues/65991).