### PR TITLE
fix(rust): use iter to avoid reallocate

### DIFF
--- a/rust/fury-core/src/resolver/meta_resolver.rs
+++ b/rust/fury-core/src/resolver/meta_resolver.rs
@@ -69,7 +69,7 @@ impl<'a> MetaWriterResolver<'a> {
 
     pub fn to_bytes(&self, writer: &mut Writer) -> Result<(), Error> {
         writer.var_int32(self.type_defs.len() as i32);
-        for item in self.type_defs.iter() {
+        for item in &self.type_defs {
             writer.bytes(item)
         }
         Ok(())

--- a/rust/fury-core/src/serializer/list.rs
+++ b/rust/fury-core/src/serializer/list.rs
@@ -38,14 +38,11 @@ where
     }
 
     fn read(context: &mut ReadContext) -> Result<Self, Error> {
-        // length
+        // vec length
         let len = context.reader.var_int32();
-        // value
-        let mut result = Vec::new();
-        for _ in 0..len {
-            result.push(T::deserialize(context)?);
-        }
-        Ok(result)
+        (0..len)
+            .map(|_| T::deserialize(context))
+            .collect::<Result<Vec<_>, Error>>()
     }
 
     fn reserved_space() -> usize {

--- a/rust/fury-core/src/serializer/mod.rs
+++ b/rust/fury-core/src/serializer/mod.rs
@@ -67,8 +67,8 @@ pub trait Serializer
 where
     Self: Sized,
 {
-    /// The fixed memory size of the Type.
-    /// Avoid the memory check, which would hurt performance.
+    /// The possible max memory size of the type.
+    /// Used to reserve the buffer space to avoid reallocation, which may hurt performance.
     fn reserved_space() -> usize;
 
     /// Write the data into the buffer.

--- a/rust/fury-core/src/serializer/set.rs
+++ b/rust/fury-core/src/serializer/set.rs
@@ -42,12 +42,9 @@ impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
     fn read(context: &mut ReadContext) -> Result<Self, Error> {
         // length
         let len = context.reader.var_int32();
-        let mut result = HashSet::new();
-        // key-value
-        for _ in 0..len {
-            result.insert(<T as Serializer>::deserialize(context)?);
-        }
-        Ok(result)
+        (0..len)
+            .map(|_| T::deserialize(context))
+            .collect::<Result<HashSet<_>, Error>>()
     }
 
     fn reserved_space() -> usize {


### PR DESCRIPTION

## What does this PR do?

Use iterator + collect to avoid re-allocate vec/set/map.

## Related issues

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
