### PR TITLE
refactor(rust): simplify error handle

### DIFF
--- a/rust/fury-core/Cargo.toml
+++ b/rust/fury-core/Cargo.toml
@@ -28,6 +28,7 @@ quote = { default-features = false, version = "1.0" }
 byteorder = { version = "1.4" }
 chrono = "0.4"
 thiserror = { default-features = false, version = "1.0" }
+anyhow = "1"
 num_enum = "0.5.1"
 
 

--- a/rust/fury-core/src/error.rs
+++ b/rust/fury-core/src/error.rs
@@ -47,3 +47,6 @@ macro_rules! ensure {
         }
     };
 }
+
+// Re-export anyhow::Error since it may appear in the public API.
+pub use anyhow::Error as AnyhowError;

--- a/rust/fury-core/src/error.rs
+++ b/rust/fury-core/src/error.rs
@@ -15,51 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::types::Language;
+use thiserror::Error;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
-    #[error("Field is not Option type, can't be deserialize of None")]
-    Null,
-
     #[error("Fury on Rust not support Ref type")]
     Ref,
-
-    #[error("Fury on Rust not support RefValue type")]
-    RefValue,
-
-    #[error("BadRefFlag")]
-    BadRefFlag,
-
-    #[error("Bad FieldType; expected: {expected:?}, actual: {actual:?}")]
-    FieldType { expected: i16, actual: i16 },
-
-    #[error("Bad timestamp; out-of-range number of milliseconds")]
-    NaiveDateTime,
-
-    #[error("Bad date; out-of-range")]
-    NaiveDate,
-
-    #[error("Schema is not consistent; expected: {expected:?}, actual: {actual:?}")]
-    StructHash { expected: u32, actual: u32 },
-
-    #[error("Bad Tag Type: {0}")]
-    TagType(u8),
-
-    #[error("Only Xlang supported; receive: {language:?}")]
-    UnsupportedLanguage { language: Language },
-
-    #[error("Unsupported Language Code; receive: {code:?}")]
-    UnsupportedLanguageCode { code: u8 },
-
-    #[error("Unsupported encoding of field name in type meta; receive: {code:?}")]
-    UnsupportedTypeMetaFieldNameEncoding { code: u8 },
-
-    #[error("encoded_data cannot be empty")]
-    EncodedDataEmpty,
-
-    #[error("Long meta string than 32767 is not allowed")]
-    LengthExceed,
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/rust/fury-core/src/error.rs
+++ b/rust/fury-core/src/error.rs
@@ -61,21 +61,27 @@ pub enum Error {
     #[error("Long meta string than 32767 is not allowed")]
     LengthExceed,
 
-    #[error("Non-ASCII characters in meta string are not allowed")]
-    OnlyAllowASCII,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
 
-    #[error("Unsupported character for LOWER_SPECIAL encoding: {ch:?}")]
-    UnsupportedLowerSpecialCharacter { ch: char },
-
-    #[error("Unsupported character for LOWER_UPPER_DIGIT_SPECIAL encoding: {ch:?}")]
-    UnsupportedLowerUpperDigitSpecialCharacter { ch: char },
-
-    #[error("Invalid character value for LOWER_SPECIAL decoding: {value:?}")]
-    InvalidLowerSpecialValue { value: u8 },
-
-    #[error("Invalid character value for LOWER_UPPER_DIGIT_SPECIAL decoding: {value:?}")]
-    InvalidLowerUpperDigitSpecialValue { value: u8 },
-
-    #[error("Unregistered type when serializing or deserializing object of Any type: {value:?}")]
-    UnregisteredType { value: u32 },
+/// Works like anyhow's [ensure](https://docs.rs/anyhow/latest/anyhow/macro.ensure.html)
+/// But return `Return<T, ErrorFromAnyhow>`
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $msg:literal) => {
+        if !$cond {
+            return Err(anyhow::anyhow!($msg).into());
+        }
+    };
+    ($cond:expr, $err:expr) => {
+        if !$cond {
+            return Err($err.into());
+        }
+    };
+    ($cond:expr, $fmt:expr, $($arg:tt)*) => {
+        if !$cond {
+            return Err(anyhow::anyhow!($fmt, $($arg)*).into());
+        }
+    };
 }

--- a/rust/fury-core/src/meta/type_meta.rs
+++ b/rust/fury-core/src/meta/type_meta.rs
@@ -19,6 +19,7 @@ use super::meta_string::MetaStringEncoder;
 use crate::buffer::{Reader, Writer};
 use crate::error::Error;
 use crate::meta::{Encoding, MetaStringDecoder};
+use anyhow::anyhow;
 
 pub struct FieldInfo {
     field_name: String,
@@ -38,7 +39,9 @@ impl FieldInfo {
             0x00 => Ok(Encoding::Utf8),
             0x01 => Ok(Encoding::AllToLowerSpecial),
             0x02 => Ok(Encoding::LowerUpperDigitSpecial),
-            _ => Err(Error::UnsupportedTypeMetaFieldNameEncoding { code: value }),
+            _ => Err(anyhow!(
+                "Unsupported encoding of field name in type meta, value:{value}"
+            ))?,
         }
     }
 

--- a/rust/fury-core/src/resolver/context.rs
+++ b/rust/fury-core/src/resolver/context.rs
@@ -18,6 +18,7 @@
 use crate::buffer::{Reader, Writer};
 use crate::error::Error;
 use crate::fury::Fury;
+use anyhow::anyhow;
 
 use crate::meta::TypeMeta;
 use crate::resolver::meta_resolver::{MetaReaderResolver, MetaWriterResolver};
@@ -119,7 +120,7 @@ impl<'de, 'bf: 'de> ReadContext<'de, 'bf> {
             self.tags.push(tag);
             Ok(tag)
         } else {
-            Err(Error::TagType(tag_type))
+            Err(anyhow!("Unknown tag type, value:{tag_type}"))?
         }
     }
 }

--- a/rust/fury-core/src/serializer/any.rs
+++ b/rust/fury-core/src/serializer/any.rs
@@ -20,6 +20,7 @@ use crate::fury::Fury;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::Serializer;
 use crate::types::{FieldType, Mode, RefFlag};
+use anyhow::anyhow;
 use std::any::Any;
 
 impl Serializer for Box<dyn Any> {
@@ -75,13 +76,13 @@ impl Serializer for Box<dyn Any> {
                     .get_deserializer()(context)
             }
         } else if ref_flag == (RefFlag::Null as i8) {
-            Err(Error::Null)
+            Err(anyhow!("Try to deserialize `any` to null"))?
         } else if ref_flag == (RefFlag::Ref as i8) {
             reset_cursor(&mut context.reader);
             Err(Error::Ref)
         } else {
             reset_cursor(&mut context.reader);
-            Err(Error::BadRefFlag)
+            Err(anyhow!("Unknown ref flag, value:{ref_flag}"))?
         }
     }
 }

--- a/rust/fury-core/src/serializer/mod.rs
+++ b/rust/fury-core/src/serializer/mod.rs
@@ -15,10 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::ensure;
 use crate::error::Error;
 use crate::fury::Fury;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::types::RefFlag;
+use anyhow::anyhow;
 
 mod any;
 mod bool;
@@ -46,20 +48,18 @@ pub fn deserialize<T: Serializer>(context: &mut ReadContext) -> Result<T, Error>
     if ref_flag == (RefFlag::NotNullValue as i8) || ref_flag == (RefFlag::RefValue as i8) {
         let actual_type_id = context.reader.i16();
         let expected_type_id = T::get_type_id(context.get_fury());
-        if actual_type_id != expected_type_id {
-            Err(Error::FieldType {
-                expected: expected_type_id,
-                actual: actual_type_id,
-            })
-        } else {
-            Ok(T::read(context)?)
-        }
+        ensure!(
+            actual_type_id == expected_type_id,
+            anyhow!("Invalid field type, expected:{expected_type_id}, actual:{actual_type_id}")
+        );
+
+        T::read(context)
     } else if ref_flag == (RefFlag::Null as i8) {
-        Err(Error::Null)
+        Err(anyhow!("Try to deserialize non-option type to null"))?
     } else if ref_flag == (RefFlag::Ref as i8) {
         Err(Error::Ref)
     } else {
-        Err(Error::BadRefFlag)
+        Err(anyhow!("Unknown ref flag, value:{ref_flag}"))?
     }
 }
 

--- a/rust/fury-core/src/types.rs
+++ b/rust/fury-core/src/types.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::Error;
+use anyhow::anyhow;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::mem;
 
@@ -163,7 +164,7 @@ impl TryFrom<u8> for Language {
             4 => Ok(Language::Go),
             5 => Ok(Language::Javascript),
             6 => Ok(Language::Rust),
-            _ => Err(Error::UnsupportedLanguageCode { code: num }),
+            _ => Err(anyhow!("Unsupported language code, value:{num}"))?,
         }
     }
 }

--- a/rust/fury-derive/src/object/read.rs
+++ b/rust/fury-derive/src/object/read.rs
@@ -98,11 +98,11 @@ fn deserialize_compatible(fields: &[&Field]) -> TokenStream {
                 #(#create),*
             })
         } else if ref_flag == (fury_core::types::RefFlag::Null as i8) {
-            Err(anyhow::anyhow!("Try to deserialize non-option type to null"))?
+            Err(fury_core::error::AnyhowError::msg("Try to deserialize non-option type to null"))?
         } else if ref_flag == (fury_core::types::RefFlag::Ref as i8) {
             Err(fury_core::error::Error::Ref)
         } else {
-            Err(anyhow::anyhow!("Unknown ref flag, value:{:?}", ref_flag))?
+            Err(fury_core::error::AnyhowError::msg("Unknown ref flag, value:{ref_flag}"))?
         }
     }
 }

--- a/rust/fury-derive/src/object/read.rs
+++ b/rust/fury-derive/src/object/read.rs
@@ -98,11 +98,11 @@ fn deserialize_compatible(fields: &[&Field]) -> TokenStream {
                 #(#create),*
             })
         } else if ref_flag == (fury_core::types::RefFlag::Null as i8) {
-            Err(fury_core::error::Error::Null)
+            Err(anyhow::anyhow!("Try to deserialize non-option type to null"))?
         } else if ref_flag == (fury_core::types::RefFlag::Ref as i8) {
             Err(fury_core::error::Error::Ref)
         } else {
-            Err(fury_core::error::Error::BadRefFlag)
+            Err(anyhow::anyhow!("Unknown ref flag, value:{:?}", ref_flag))?
         }
     }
 }

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -27,3 +27,4 @@ fury-core = { path = "../fury-core" }
 fury-derive = { path = "../fury-derive" }
 
 chrono = "0.4"
+anyhow = "1.0"

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -27,4 +27,3 @@ fury-core = { path = "../fury-core" }
 fury-derive = { path = "../fury-derive" }
 
 chrono = "0.4"
-anyhow = "1.0"


### PR DESCRIPTION

## What does this PR do?

Make error easy to use.

In most case, users don't care about error details, so too many fields in enum is hard to write, and hard to use. 

So I refactor it to include an `Other` field to be used as a general Error, most error can be mapped to it directly.

`Ref` is a special case, so I leave it as it's now.

## Related issues


## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

