### PR TITLE
fix(java): DeserializationException#getMessage call

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/exception/DeserializationException.java
+++ b/java/fury-core/src/main/java/org/apache/fury/exception/DeserializationException.java
@@ -56,7 +56,7 @@ public class DeserializationException extends FuryException {
         for (Object readObject : readObjects) {
           builder.append(readObject == null ? null : readObject.getClass()).append(", ");
         }
-        builder.deleteCharAt(builder.length() - 1);
+        builder.delete(builder.length() - 2, builder.length());
         builder.append("]");
         return builder.toString();
       }

--- a/java/fury-core/src/main/java/org/apache/fury/exception/DeserializationException.java
+++ b/java/fury-core/src/main/java/org/apache/fury/exception/DeserializationException.java
@@ -56,7 +56,7 @@ public class DeserializationException extends FuryException {
         for (Object readObject : readObjects) {
           builder.append(readObject == null ? null : readObject.getClass()).append(", ");
         }
-        builder.delete(builder.length() - 2, 2);
+        builder.deleteCharAt(builder.length() - 1);
         builder.append("]");
         return builder.toString();
       }


### PR DESCRIPTION
## What does this PR do?

Fix failure on `DeserializationException#getMessage`

```
java.lang.StringIndexOutOfBoundsException: Range [311, 2) out of bounds for length 313
	at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
	at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
	at java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
	at java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Unknown Source)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Unknown Source)
	at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Unknown Source)
	at java.base/java.lang.AbstractStringBuilder.delete(Unknown Source)
	at java.base/java.lang.StringBuilder.delete(Unknown Source)
	at org.apache.fury.exception.DeserializationException.getMessage(DeserializationException.java:59)
```

## Related issues

N/A

## Does this PR introduce any user-facing change?

N/A

## Benchmark

N/A
