### PR TITLE
fix(java): Fix for maximum size of java arrays

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1230,7 +1230,7 @@ public final class MemoryBuffer {
     int newSize =
         length < BUFFER_GROW_STEP_THRESHOLD
             ? length << 2
-            : (int) Math.min(length * 1.5d, Integer.MAX_VALUE);
+            : (int) Math.min(length * 1.5d, Integer.MAX_VALUE - 8);
     byte[] data = new byte[newSize];
     copyToUnsafe(0, data, Platform.BYTE_ARRAY_OFFSET, size());
     initHeapBuffer(data, 0, data.length);


### PR DESCRIPTION
## What does this PR do?

Fixes the maximum size of Java arrays using Integer.MAX_VALUE when it should be Integer.MAX_VALUE - 8.
See this https://github.com/openjdk/jdk14u/blob/84917a040a81af2863fddc6eace3dda3e31bf4b5/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java#L577 or https://www.baeldung.com/java-arrays-max-size

## Related issues


- #1842

## Does this PR introduce any user-facing change?

No

- [ ] Does this PR introduce any public API change? No
- [ ] Does this PR introduce any binary protocol compatibility change? No

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
