### PR TITLE
fix(java): Fix max Java array size for reader

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/io/FuryInputStream.java
+++ b/java/fury-core/src/main/java/org/apache/fury/io/FuryInputStream.java
@@ -80,7 +80,7 @@ public class FuryInputStream extends InputStream implements FuryStreamReader {
     newSize =
         targetSize < MemoryBuffer.BUFFER_GROW_STEP_THRESHOLD
             ? targetSize << 2
-            : (int) Math.min(targetSize * 1.5d, Integer.MAX_VALUE);
+            : (int) Math.min(targetSize * 1.5d, Integer.MAX_VALUE - 8);
     byte[] newBuffer = new byte[newSize];
     byte[] heapMemory = buffer.getHeapMemory();
     System.arraycopy(heapMemory, 0, newBuffer, 0, buffer.size());


### PR DESCRIPTION
## What does this PR do?

Fixes the maximum size of Java arrays using Integer.MAX_VALUE when it should be Integer.MAX_VALUE - 8.
See this https://github.com/openjdk/jdk14u/blob/84917a040a81af2863fddc6eace3dda3e31bf4b5/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java#L577 or https://www.baeldung.com/java-arrays-max-size
Same as https://github.com/apache/fury/pull/1843 but for the reader.

## Related issues

- #1842

## Does this PR introduce any user-facing change?

No

- [ ] Does this PR introduce any public API change? No
- [ ] Does this PR introduce any binary protocol compatibility change? No

## Benchmark

Not needed
