### PR TITLE
chore(java): simplify generated codec name

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -158,7 +158,8 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     jitCallbackUpdateFields = new HashMap<>();
   }
 
-  private final Map<String, Map<String, Integer>> idGenerator = new ConcurrentHashMap<>();
+  // Must be static to be shared across the whole process life.
+  private static final Map<String, Map<String, Integer>> idGenerator = new ConcurrentHashMap<>();
 
   public String codecClassName(Class<?> beanClass) {
     String name = ReflectionUtils.getClassNameWithoutPackage(beanClass).replace("$", "_");

--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -170,15 +170,10 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     } else {
       nameBuilder.append("Fury");
     }
-    nameBuilder.append("Codec");
+    nameBuilder.append("Codec").append(codecSuffix());
     Map<String, Integer> subGenerator =
         idGenerator.computeIfAbsent(nameBuilder.toString(), k -> new ConcurrentHashMap<>());
-    String key =
-        codecSuffix()
-            + "_"
-            + fury.getConfig().getConfigHash()
-            + "_"
-            + CodeGenerator.getClassUniqueId(beanClass);
+    String key = fury.getConfig().getConfigHash() + "_" + CodeGenerator.getClassUniqueId(beanClass);
     Integer id = subGenerator.get(key);
     if (id == null) {
       synchronized (subGenerator) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.fury.Fury;
@@ -157,6 +158,8 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     jitCallbackUpdateFields = new HashMap<>();
   }
 
+  private final Map<String, Map<String, Integer>> idGenerator = new ConcurrentHashMap<>();
+
   public String codecClassName(Class<?> beanClass) {
     String name = ReflectionUtils.getClassNameWithoutPackage(beanClass).replace("$", "_");
     StringBuilder nameBuilder = new StringBuilder(name);
@@ -167,12 +170,22 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     } else {
       nameBuilder.append("Fury");
     }
-    nameBuilder.append(codecSuffix()).append("Codec");
-    nameBuilder.append('_').append(fury.getConfig().getConfigHash());
-    String classUniqueId = CodeGenerator.getClassUniqueId(beanClass);
-    if (StringUtils.isNotBlank(classUniqueId)) {
-      nameBuilder.append('_').append(classUniqueId);
+    nameBuilder.append("Codec");
+    Map<String, Integer> subGenerator =
+        idGenerator.computeIfAbsent(nameBuilder.toString(), k -> new ConcurrentHashMap<>());
+    String key =
+        codecSuffix()
+            + "_"
+            + fury.getConfig().getConfigHash()
+            + "_"
+            + CodeGenerator.getClassUniqueId(beanClass);
+    Integer id = subGenerator.get(key);
+    if (id == null) {
+      synchronized (subGenerator) {
+        id = subGenerator.computeIfAbsent(key, k -> subGenerator.size());
+      }
     }
+    nameBuilder.append('_').append(id);
     return nameBuilder.toString();
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/builder/MetaSharedCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/MetaSharedCodecBuilder.java
@@ -22,7 +22,9 @@ package org.apache.fury.builder;
 import static org.apache.fury.builder.Generated.GeneratedMetaSharedSerializer.SERIALIZER_FIELD_NAME;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.fury.Fury;
 import org.apache.fury.builder.Generated.GeneratedMetaSharedSerializer;
 import org.apache.fury.codegen.CodeGenerator;
@@ -86,11 +88,19 @@ public class MetaSharedCodecBuilder extends ObjectCodecBuilder {
         new ObjectCodecOptimizer(beanClass, grouper, !fury.isBasicTypesRefIgnored(), ctx);
   }
 
+  private final Map<Long, Integer> idGenerator = new ConcurrentHashMap<>();
+
   @Override
   protected String codecSuffix() {
     // For every class def sent from different peer, if the class def are different, then
     // a new serializer needs being generated.
-    return "MetaShared" + classDef.getId();
+    Integer id = idGenerator.get(classDef.getId());
+    if (id == null) {
+      synchronized (idGenerator) {
+        id = idGenerator.computeIfAbsent(classDef.getId(), k -> idGenerator.size());
+      }
+    }
+    return "MetaShared" + id;
   }
 
   @Override

--- a/java/fury-core/src/main/java/org/apache/fury/builder/MetaSharedCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/MetaSharedCodecBuilder.java
@@ -88,7 +88,8 @@ public class MetaSharedCodecBuilder extends ObjectCodecBuilder {
         new ObjectCodecOptimizer(beanClass, grouper, !fury.isBasicTypesRefIgnored(), ctx);
   }
 
-  private final Map<Long, Integer> idGenerator = new ConcurrentHashMap<>();
+  // Must be static to be shared across the whole process life.
+  private static final Map<Long, Integer> idGenerator = new ConcurrentHashMap<>();
 
   @Override
   protected String codecSuffix() {


### PR DESCRIPTION


## What does this PR do?

simplify generated codec name

before:
![image](https://github.com/user-attachments/assets/bbb51fe7-23d1-405a-89c4-e4d0c4c8ab60)

after:
![image](https://github.com/user-attachments/assets/f3540884-89e7-4a81-9d04-d3dff66ff379)

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
