### PR TITLE
feat(java): use SubListViewSerializer only when tracking ref

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/SubListSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/SubListSerializers.java
@@ -78,8 +78,8 @@ public class SubListSerializers {
         new Class[] {
           SubListClass, RandomAccessSubListClass, ArrayListSubListClass, ImmutableSubListClass
         }) {
-      if (preserveView && fury.getConfig().getLanguage() == Language.JAVA) {
-        fury.registerSerializer(cls, new SubListViewSerializer(fury, (Class<List>) cls));
+      if (fury.trackingRef() && preserveView && fury.getConfig().getLanguage() == Language.JAVA) {
+        fury.registerSerializer(cls, new SubListViewSerializer(fury, cls));
       } else {
         fury.registerSerializer(cls, new SubListSerializer(fury, (Class<List>) cls));
       }

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/collection/SubListSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/collection/SubListSerializersTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class SubListSerializersTest extends FuryTestBase {
   @Test
   public void testSubListViewSerialization() {
-    Fury fury = builder().build();
+    Fury fury = builder().withRefTracking(true).build();
     List<Integer> data = new ArrayList<>();
     Collections.addAll(data, 1, 2, 3, 4, 5, 6, 7);
     int length = fury.serialize(data).length;
@@ -65,8 +65,7 @@ public class SubListSerializersTest extends FuryTestBase {
 
   @Test
   public void testSubListNoViewSerialization() {
-    Fury fury = builder().build();
-    SubListSerializers.registerSerializers(fury, false);
+    Fury fury = builder().withRefTracking(false).build();
     List<Integer> data = new ArrayList<>();
     Collections.addAll(data, 1, 2, 3, 4, 5, 6, 7);
     int length = fury.serialize(data).length;


### PR DESCRIPTION

## What does this PR do?

use SubListViewSerializer only when tracking ref

## Related issues
Closes #1198

#1856 

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
