### PR TITLE
ci: only run sync job if the repo is apache/fury

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/fury'
     steps:
       - uses: actions/checkout@v4
       - name: Sync files


### PR DESCRIPTION
The sync job is set up so it also runs on forks of the apache/fury repo. It can't pass on the forks because they don't have the secrets set up.