### PR TITLE
feat(kotlin): Add Unsigned Primitive Support

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -8,11 +8,14 @@ Fury Kotlin provides additional tests and implementation support for Kotlin type
 
 Fury Kotlin is tested and works with the following types:
 
+- primitives: `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double`, `UByte`, `UShort`, `UInt`, `UShort`, `UInt`.
+-  `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double` works out of the box with the default java implementation.
 - stdlib `collection`: `ArrayDeque`, `ArrayList`, `HashMap`,`HashSet`, `LinkedHashSet`, `LinkedHashMap`.
 - `ArrayList`, `HashMap`,`HashSet`, `LinkedHashSet`, `LinkedHashMap` works out of the box with the default java implementation.
 
 Additional support is added for the following classes in kotlin:
 
+- Unsigned primitives: `UByte`, `UShort`, `UInt`, `ULong`
 - Empty collections: `emptyList`, `emptyMap`, `emptySet`
 - Collections: `ArrayDeque`
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -9,7 +9,7 @@ Fury Kotlin provides additional tests and implementation support for Kotlin type
 Fury Kotlin is tested and works with the following types:
 
 - primitives: `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double`, `UByte`, `UShort`, `UInt`, `UShort`, `UInt`.
--  `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double` works out of the box with the default java implementation.
+- `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double` works out of the box with the default java implementation.
 - stdlib `collection`: `ArrayDeque`, `ArrayList`, `HashMap`,`HashSet`, `LinkedHashSet`, `LinkedHashMap`.
 - `ArrayList`, `HashMap`,`HashSet`, `LinkedHashSet`, `LinkedHashMap` works out of the box with the default java implementation.
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -9,9 +9,9 @@ Fury Kotlin provides additional tests and implementation support for Kotlin type
 Fury Kotlin is tested and works with the following types:
 
 - primitives: `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double`, `UByte`, `UShort`, `UInt`, `UShort`, `UInt`.
-- `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double` works out of the box with the default java implementation.
+- `Byte`, `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double` works out of the box with the default fury java implementation.
 - stdlib `collection`: `ArrayDeque`, `ArrayList`, `HashMap`,`HashSet`, `LinkedHashSet`, `LinkedHashMap`.
-- `ArrayList`, `HashMap`,`HashSet`, `LinkedHashSet`, `LinkedHashMap` works out of the box with the default java implementation.
+- `ArrayList`, `HashMap`,`HashSet`, `LinkedHashSet`, `LinkedHashMap` works out of the box with the default fury java implementation.
 
 Additional support is added for the following classes in kotlin:
 

--- a/kotlin/src/main/java/org/apache/fury/serializer/kotlin/KotlinSerializers.java
+++ b/kotlin/src/main/java/org/apache/fury/serializer/kotlin/KotlinSerializers.java
@@ -33,6 +33,26 @@ public class KotlinSerializers {
     public static void registerSerializers(Fury fury) {
         ClassResolver resolver = fury.getClassResolver();
 
+        // UByte
+        Class ubyteClass = KotlinToJavaClass.INSTANCE.getUByteClass();
+        resolver.register(ubyteClass);
+        resolver.registerSerializer(ubyteClass, new UByteSerializer(fury));
+
+        // UShort
+        Class ushortClass = KotlinToJavaClass.INSTANCE.getUShortClass();
+        resolver.register(ushortClass);
+        resolver.registerSerializer(ushortClass, new UShortSerializer(fury));
+
+        // UInt
+        Class uintClass = KotlinToJavaClass.INSTANCE.getUIntClass();
+        resolver.register(uintClass);
+        resolver.registerSerializer(uintClass, new UIntSerializer(fury));
+
+        // ULong
+        Class ulongClass = KotlinToJavaClass.INSTANCE.getULongClass();
+        resolver.register(ulongClass);
+        resolver.registerSerializer(ulongClass, new ULongSerializer(fury));
+
         // EmptyList
         Class emptyListClass = KotlinToJavaClass.INSTANCE.getEmptyListClass();
         resolver.register(emptyListClass);

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/KotlinToJavaClass.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/KotlinToJavaClass.kt
@@ -20,8 +20,15 @@
 package org.apache.fury.serializer.kotlin
 
 object KotlinToJavaClass {
+    // Collections
     val ArrayDequeClass = ArrayDeque::class.java
     val EmptyListClass = emptyList<Any>().javaClass
     val EmptySetClass = emptySet<Any>().javaClass
     val EmptyMapClass = emptyMap<Any, Any>().javaClass
+
+    // Unsigned
+    val UByteClass = UByte::class.java
+    val UShortClass = UShort::class.java
+    val UIntClass = UInt::class.java
+    val ULongClass = ULong::class.java
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -44,7 +44,7 @@ class UByteSerializer(
     }
 
     override fun read(buffer: MemoryBuffer): UByte {
-        return buffer.readVarUint32().toUByte()
+        return buffer.readByte().toUByte()
     }
 }
 

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.fury.serializer.kotlin
 
 import org.apache.fury.Fury

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -1,0 +1,76 @@
+package org.apache.fury.serializer.kotlin
+
+import org.apache.fury.Fury
+import org.apache.fury.memory.MemoryBuffer
+import org.apache.fury.serializer.Serializers
+import org.apache.fury.type.Type
+
+class UByteSerializer(
+    fury: Fury,
+) : Serializers.CrossLanguageCompatibleSerializer<UByte>(
+    fury,
+    UByte::class.java,
+    Type.UINT8.id,
+    fury.isBasicTypesRefIgnored,
+    true) {
+
+    override fun write(buffer: MemoryBuffer, value: UByte) {
+        buffer.writeVarUint32Small7(value.toInt())
+    }
+
+    override fun read(buffer: MemoryBuffer): UByte {
+        return buffer.readVarUint32().toUByte()
+    }
+}
+
+class UShortSerializer(
+    fury: Fury,
+) : Serializers.CrossLanguageCompatibleSerializer<UShort>(
+    fury,
+    UShort::class.java,
+    Type.UINT16.id,
+    fury.isBasicTypesRefIgnored,
+    true
+) {
+    override fun write(buffer: MemoryBuffer, value: UShort) {
+        buffer.writeVarUint32(value.toInt())
+    }
+    override fun read(buffer: MemoryBuffer): UShort {
+        return buffer.readVarUint32().toUShort()
+    }
+}
+
+class UIntSerializer(
+    fury: Fury,
+) : Serializers.CrossLanguageCompatibleSerializer<UInt>(
+    fury,
+    UInt::class.java,
+    Type.UINT32.id,
+    fury.isBasicTypesRefIgnored,
+    true) {
+
+    override fun write(buffer: MemoryBuffer, value: UInt) {
+        buffer.writeVarUint32(value.toInt())
+    }
+
+    override fun read(buffer: MemoryBuffer): UInt {
+        return buffer.readVarUint32().toUInt()
+    }
+}
+
+class ULongSerializer(
+    fury: Fury,
+) : Serializers.CrossLanguageCompatibleSerializer<ULong>(
+    fury,
+    ULong::class.java,
+    Type.UINT64.id,
+    fury.isBasicTypesRefIgnored,
+    true
+) {
+    override fun write(buffer: MemoryBuffer, value: ULong) {
+        buffer.writeVarUint64(value.toLong())
+    }
+    override fun read(buffer: MemoryBuffer): ULong {
+        return buffer.readVarUint64().toULong()
+    }
+}

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -24,6 +24,12 @@ import org.apache.fury.memory.MemoryBuffer
 import org.apache.fury.serializer.Serializers
 import org.apache.fury.type.Type
 
+/**
+ * UByteSerializer
+ *
+ * UByte is mapped to Type.UINT8
+ *
+ */
 class UByteSerializer(
     fury: Fury,
 ) : Serializers.CrossLanguageCompatibleSerializer<UByte>(
@@ -42,6 +48,13 @@ class UByteSerializer(
     }
 }
 
+
+/**
+ * UShortSerializer
+ *
+ * UShort is mapped to Type.UINT16.
+ *
+ */
 class UShortSerializer(
     fury: Fury,
 ) : Serializers.CrossLanguageCompatibleSerializer<UShort>(
@@ -59,6 +72,12 @@ class UShortSerializer(
     }
 }
 
+/**
+ * UInt Serializer
+ *
+ * UInt is mapped to Type.UINT32.
+ *
+ */
 class UIntSerializer(
     fury: Fury,
 ) : Serializers.CrossLanguageCompatibleSerializer<UInt>(
@@ -77,6 +96,12 @@ class UIntSerializer(
     }
 }
 
+/**
+ * ULong Serializer
+ *
+ * ULong is mapped to Type.UINT64.
+ *
+ */
 class ULongSerializer(
     fury: Fury,
 ) : Serializers.CrossLanguageCompatibleSerializer<ULong>(

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -65,10 +65,10 @@ class UShortSerializer(
     true
 ) {
     override fun write(buffer: MemoryBuffer, value: UShort) {
-        buffer.writeVarUint32(value.toInt())
+        buffer.writeVarUint16(value.toInt())
     }
     override fun read(buffer: MemoryBuffer): UShort {
-        return buffer.readVarUint32().toUShort()
+        return buffer.readVarUint16().toUShort()
     }
 }
 

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -65,10 +65,10 @@ class UShortSerializer(
     true
 ) {
     override fun write(buffer: MemoryBuffer, value: UShort) {
-        buffer.writeVarUint32(value.toInt())
+        buffer.writeInt16(value.toShort())
     }
     override fun read(buffer: MemoryBuffer): UShort {
-        return buffer.readVarUint32().toUShort()
+        return buffer.readInt16().toUShort()
     }
 }
 

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -40,7 +40,7 @@ class UByteSerializer(
     true) {
 
     override fun write(buffer: MemoryBuffer, value: UByte) {
-        buffer.writeVarUint32Small7(value.toInt())
+        buffer.writeByte(value.toInt())
     }
 
     override fun read(buffer: MemoryBuffer): UByte {

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -65,10 +65,10 @@ class UShortSerializer(
     true
 ) {
     override fun write(buffer: MemoryBuffer, value: UShort) {
-        buffer.writeInt16(value.toShort())
+        buffer.writeVarUint32(value.toInt())
     }
     override fun read(buffer: MemoryBuffer): UShort {
-        return buffer.readInt16().toUShort()
+        return buffer.readVarUint32().toUShort()
     }
 }
 

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -65,10 +65,10 @@ class UShortSerializer(
     true
 ) {
     override fun write(buffer: MemoryBuffer, value: UShort) {
-        buffer.writeVarUint16(value.toInt())
+        buffer.writeVarUint32(value.toInt())
     }
     override fun read(buffer: MemoryBuffer): UShort {
-        return buffer.readVarUint16().toUShort()
+        return buffer.readVarUint32().toUShort()
     }
 }
 

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/NullablePrimitiveSerializerTests.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/NullablePrimitiveSerializerTests.kt
@@ -25,7 +25,10 @@ import org.testng.Assert
 import org.testng.annotations.Test
 
 /**
- * Nullable primitive serializer tests
+ * Nullable primitive serializer tests.
+ *
+ * Nullable primitives get translated into Boxed types in java.
+ * See: https://kotlinlang.org/docs/numbers.html#numbers-representation-on-the-jvm
  *
  */
 class NullablePrimitiveSerializerTests {

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/NullablePrimitiveSerializerTests.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/NullablePrimitiveSerializerTests.kt
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.serializer.kotlin
+
+import org.apache.fury.Fury
+import org.apache.fury.config.Language
+import org.testng.Assert
+import org.testng.annotations.Test
+
+/**
+ * Nullable primitive serializer tests
+ *
+ */
+class NullablePrimitiveSerializerTests {
+    @Test
+    fun testSerializeBoxedByteValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Byte? = 42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeBoxedIntValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Int? = 42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeBoxedShortValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Short? = 42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBoxedLongValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Long? = 42L
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBoxedFloatValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Float? = .42f
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBoxedDoubleValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: Double? = .42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBoxedBooleanValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: Boolean? = true
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeBoxedCharValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: Char? = 'a'
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBoxedUByteValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: UByte? = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBoxedUShortValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: UShort? = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBoxedUIntValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: UInt? = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeBoxedULongValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: ULong? = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+}

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/PrimitiveSerializerTest.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/PrimitiveSerializerTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.serializer.kotlin
+
+import org.apache.fury.Fury
+import org.apache.fury.config.Language
+import org.testng.Assert
+import org.testng.annotations.Test
+
+class PrimitiveSerializerTest {
+    @Test
+    fun testSerializeByteValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Byte = 42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeIntValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Int = 42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeShortValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Short = 42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeLongValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Long = 42L
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeFloatValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value:Float = .42f
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeDoubleValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: Double = .42
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeBooleanValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: Boolean = true
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeCharValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: Char = 'a'
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeUByteValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: UByte = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeUShortValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: UShort = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+
+    @Test
+    fun testSerializeUIntValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: UInt = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+    @Test
+    fun testSerializeULongValue() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+        val value: ULong = 42u
+        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+    }
+}

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/UnsignedBoundarySerializerTests.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/UnsignedBoundarySerializerTests.kt
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.serializer.kotlin
+
+import org.apache.fury.Fury
+import org.apache.fury.config.Language
+import org.testng.Assert
+import org.testng.annotations.Test
+
+class UnsignedBoundarySerializerTests {
+    @Test
+    fun testUByteBoundarySerialization() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+
+        val boundaryMin = UByte.MIN_VALUE
+        val boundaryMax = UByte.MAX_VALUE
+
+        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+    }
+
+    @Test
+    fun testUShortBoundarySerialization() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+
+        val boundaryMin = UShort.MIN_VALUE
+        val boundaryMax = UShort.MAX_VALUE
+
+        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+    }
+
+    @Test
+    fun testUIntBoundarySerialization() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+
+        val boundaryMin = UInt.MIN_VALUE
+        val boundaryMax = UInt.MAX_VALUE
+
+        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+    }
+
+    @Test
+    fun testULongBoundarySerialization() {
+        val fury: Fury = Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(true)
+            .build()
+
+        KotlinSerializers.registerSerializers(fury)
+
+        val boundaryMin = ULong.MIN_VALUE
+        val boundaryMax = ULong.MAX_VALUE
+
+        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+    }
+}


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR adds unsigned primitive support to Kotlin Fury.
It also adds tests for the standard kotlin primitives(supported by fury Java), nullable primitive tests, boundary tests for unsigned serializers.

## Related issues
#683

## Does this PR introduce any user-facing change?

Yes it adds Unsigned support for Kotlin. There's documentation new issue (should add something to document Kotlin!)

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
N/A
