### PR TITLE
chore(py314): Replace deprecated pkgutil.find_loader

### DIFF
--- a/python/pyfury/util.py
+++ b/python/pyfury/util.py
@@ -17,7 +17,7 @@
 
 import importlib
 import inspect
-import pkgutil
+import importlib.util
 import sys
 from typing import Dict, Callable
 
@@ -61,7 +61,7 @@ def lazy_import(
             self._on_loads.append(func)
             return func
 
-    if pkgutil.find_loader(prefix_name) is not None:
+    if importlib.util.find_spec(prefix_name) is not None:
         return LazyModule()
     elif placeholder:
         return ModulePlaceholder(prefix_name)

--- a/python/pyfury/util.py
+++ b/python/pyfury/util.py
@@ -17,7 +17,6 @@
 
 import importlib
 import inspect
-import importlib.util
 import sys
 from typing import Dict, Callable
 


### PR DESCRIPTION
This PR removes [pkgutil.find_loader()][] and replaces it with [importlib.util.find_spec()][]. `find_loader` was deprecated in Python 3.12 and will be removed in 3.14. `find_spec` has been present since Python 3.4.

Both functions return `None` if the module loader cannot be found. For its use in this project, this is sufficient and no translation of the return value is needed.

[pkgutil.find_loader()]: https://docs.python.org/3/library/pkgutil.html#pkgutil.get_loader
[importlib.util.find_spec()]: https://docs.python.org/3/library/importlib.html#importlib.util.find_spec
