### PR TITLE
fix(java): NonExistentEnum on mode serializeEnumByName

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/serializer/NonexistentClassSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/NonexistentClassSerializers.java
@@ -34,6 +34,7 @@ import org.apache.fury.resolver.ClassInfo;
 import org.apache.fury.resolver.ClassInfoHolder;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.resolver.MetaContext;
+import org.apache.fury.resolver.MetaStringResolver;
 import org.apache.fury.resolver.RefResolver;
 import org.apache.fury.serializer.NonexistentClass.NonexistentEnum;
 import org.apache.fury.type.Descriptor;
@@ -226,14 +227,21 @@ public final class NonexistentClassSerializers {
 
   public static final class NonexistentEnumClassSerializer extends Serializer {
     private final NonexistentEnum[] enumConstants;
+    private final MetaStringResolver metaStringResolver;
 
     public NonexistentEnumClassSerializer(Fury fury) {
       super(fury, NonexistentEnum.class);
+      metaStringResolver = fury.getMetaStringResolver();
       enumConstants = NonexistentEnum.class.getEnumConstants();
     }
 
     @Override
     public Object read(MemoryBuffer buffer) {
+      if (fury.getConfig().serializeEnumByName()) {
+        metaStringResolver.readMetaStringBytes(buffer);
+        return NonexistentEnum.UNKNOWN;
+      }
+
       int ordinal = buffer.readVarUint32Small7();
       if (ordinal >= enumConstants.length) {
         ordinal = enumConstants.length - 1;

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/NonexistentClassSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/NonexistentClassSerializersTest.java
@@ -123,6 +123,28 @@ public class NonexistentClassSerializersTest extends FuryTestBase {
   }
 
   @Test(dataProvider = "scopedMetaShare")
+  public void testNonexistentEnum_AsString(boolean scopedMetaShare) {
+    Fury fury =
+        furyBuilder(scopedMetaShare)
+            .withDeserializeNonexistentClass(true)
+            .serializeEnumByName(true)
+            .build();
+    String enumCode = ("enum TestEnum {" + " A, B" + "}");
+    Class<?> cls = JaninoUtils.compileClass(getClass().getClassLoader(), "", "TestEnum", enumCode);
+    Object c = cls.getEnumConstants()[1];
+    assertEquals(c.toString(), "B");
+    byte[] bytes = fury.serialize(c);
+    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+    Fury fury2 =
+        furyBuilder(scopedMetaShare)
+            .withDeserializeNonexistentClass(true)
+            .serializeEnumByName(true)
+            .build();
+    Object o = fury2.deserialize(bytes);
+    assertEquals(o, NonexistentClass.NonexistentEnum.UNKNOWN);
+  }
+
+  @Test(dataProvider = "scopedMetaShare")
   public void testNonexistentEnumAndArrayField(boolean scopedMetaShare) throws Exception {
     String enumStructCode1 =
         ("public class TestEnumStruct {\n"


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
Handle NonExistentEnum on mode serializeEnumByName by returning UNKNOWN. since there are no relevancy anymore by using enum ordinal.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
