### PR TITLE
docs(guide): Fix package typo

### DIFF
--- a/docs/guide/java_serialization_guide.md
+++ b/docs/guide/java_serialization_guide.md
@@ -321,7 +321,7 @@ Or implement `java.io.Externalizable` for a class.
 ```java
 import org.apache.fury.*;
 import org.apache.fury.config.*;
-import org.apache.fury.serializers.BufferObject;
+import org.apache.fury.serializer.BufferObject;
 import org.apache.fury.memory.MemoryBuffer;
 
 import java.util.*;

--- a/docs/guide/xlang_serialization_guide.md
+++ b/docs/guide/xlang_serialization_guide.md
@@ -523,7 +523,7 @@ Reference cannot be implemented because of rust ownership restrictions
 ```java
 import org.apache.fury.*;
 import org.apache.fury.config.*;
-import org.apache.fury.serializers.BufferObject;
+import org.apache.fury.serializer.BufferObject;
 import org.apache.fury.memory.MemoryBuffer;
 
 import java.util.*;


### PR DESCRIPTION
Fixes two small typos in the guide