### PR TITLE
fix(java): ThreadLocalFury and ThreadPoolFury prioritize using the user classloader

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/ThreadLocalFury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/ThreadLocalFury.java
@@ -47,6 +47,8 @@ public class ThreadLocalFury extends AbstractThreadSafeFury {
   private Consumer<Fury> factoryCallback;
   private final WeakHashMap<LoaderBinding, Object> allFury;
 
+  private ClassLoader classLoader;
+
   public ThreadLocalFury(Function<ClassLoader, Fury> furyFactory) {
     factoryCallback = f -> {};
     allFury = new WeakHashMap<>();
@@ -55,7 +57,11 @@ public class ThreadLocalFury extends AbstractThreadSafeFury {
             () -> {
               LoaderBinding binding = new LoaderBinding(furyFactory);
               binding.setBindingCallback(factoryCallback);
-              binding.setClassLoader(Thread.currentThread().getContextClassLoader());
+              ClassLoader cl =
+                  classLoader == null
+                      ? Thread.currentThread().getContextClassLoader()
+                      : classLoader;
+              binding.setClassLoader(cl);
               allFury.put(binding, null);
               return binding;
             });
@@ -254,6 +260,7 @@ public class ThreadLocalFury extends AbstractThreadSafeFury {
 
   @Override
   public void setClassLoader(ClassLoader classLoader, StagingType stagingType) {
+    this.classLoader = classLoader;
     bindingThreadLocal.get().setClassLoader(classLoader, stagingType);
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/pool/FuryPooledObjectFactory.java
+++ b/java/fury-core/src/main/java/org/apache/fury/pool/FuryPooledObjectFactory.java
@@ -22,7 +22,6 @@ package org.apache.fury.pool;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.fury.Fury;

--- a/java/fury-core/src/main/java/org/apache/fury/pool/FuryPooledObjectFactory.java
+++ b/java/fury-core/src/main/java/org/apache/fury/pool/FuryPooledObjectFactory.java
@@ -49,15 +49,14 @@ public class FuryPooledObjectFactory {
    */
   final Cache<ClassLoader, ClassLoaderFuryPooled> classLoaderFuryPooledCache;
 
-  private final AtomicReference<ClassLoader> classLoaderRef = new AtomicReference<>();
+  private volatile ClassLoader classLoader = null;
 
   /** ThreadLocal: ClassLoader. */
   private final ThreadLocal<ClassLoader> classLoaderLocal =
       ThreadLocal.withInitial(
           () -> {
-            ClassLoader cl = classLoaderRef.get();
-            if (cl != null) {
-              return cl;
+            if (classLoader != null) {
+              return classLoader;
             }
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
             if (loader == null) {
@@ -118,7 +117,7 @@ public class FuryPooledObjectFactory {
       // may be used to clear some classloader
       classLoader = Fury.class.getClassLoader();
     }
-    classLoaderRef.set(classLoader);
+    this.classLoader = classLoader;
     classLoaderLocal.set(classLoader);
     getOrAddCache(classLoader);
   }

--- a/java/fury-core/src/test/java/org/apache/fury/classloader/ThreadSafeFuryClassLoaderTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/classloader/ThreadSafeFuryClassLoaderTest.java
@@ -1,0 +1,54 @@
+package org.apache.fury.classloader;
+
+import org.apache.fury.Fury;
+import org.apache.fury.ThreadSafeFury;
+import org.apache.fury.config.Language;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ThreadSafeFuryClassLoaderTest {
+
+  static class MyClassLoader extends ClassLoader {}
+
+  @Test
+  void testFuryThreadLocalUseProvidedClassLoader() throws InterruptedException {
+    final MyClassLoader myClassLoader = new MyClassLoader();
+    final ThreadSafeFury fury =
+        Fury.builder()
+            .withClassLoader(myClassLoader)
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(false)
+            .buildThreadLocalFury();
+    fury.setClassLoader(myClassLoader);
+
+    Thread thread =
+        new Thread(
+            () -> {
+              final ClassLoader t = fury.getClassLoader();
+              Assert.assertEquals(t, myClassLoader);
+            });
+    thread.start();
+    thread.join();
+  }
+
+  @Test
+  void testFuryPoolUseProvidedClassLoader() throws InterruptedException {
+    final MyClassLoader myClassLoader = new MyClassLoader();
+    final ThreadSafeFury fury =
+        Fury.builder()
+            .withClassLoader(myClassLoader)
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(false)
+            .buildThreadSafeFuryPool(1, 1);
+    fury.setClassLoader(myClassLoader);
+
+    Thread thread =
+        new Thread(
+            () -> {
+              final ClassLoader t = fury.getClassLoader();
+              Assert.assertEquals(t, myClassLoader);
+            });
+    thread.start();
+    thread.join();
+  }
+}

--- a/java/fury-core/src/test/java/org/apache/fury/classloader/ThreadSafeFuryClassLoaderTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/classloader/ThreadSafeFuryClassLoaderTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.fury.classloader;
 
 import org.apache.fury.Fury;


### PR DESCRIPTION

<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
ThreadLocalFury and ThreadPoolFury prioritize using the user-specified ClassLoader


<!-- Describe the purpose of this PR. -->

## Related issues
[1884](https://github.com/apache/fury/issues/1884)  [1878](https://github.com/apache/fury/issues/1878)
<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
