### PR TITLE
build(kotlin): Add spotless ktfmt and enable explicit api mode for library code.

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -42,6 +42,7 @@ Additional Notes:
 mvn clean
 mvn -T10 compile
 ```
+
 ## Code Format
 
 ```bash

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -35,3 +35,21 @@ Additional support is added for the following classes in kotlin:
 Additional Notes:
 
 - wrappers classes created from `withDefault` method is currently not supported.
+
+## Building Fury Kotlin
+
+```bash
+mvn clean
+mvn -T10 compile
+```
+## Code Format
+
+```bash
+mvn -T10 spotless:apply
+```
+
+## Testing
+
+```bash
+mvn -T10 test
+```

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -152,6 +152,8 @@
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                             </sourceDirs>
+                            <args>
+                            </args>
                         </configuration>
                     </execution>
                 </executions>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -32,8 +32,8 @@
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+      <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+      <maven-spotless-plugin.version>2.43.0</maven-spotless-plugin.version>
     </properties>
 
     <build>
@@ -166,6 +166,26 @@
                 <configuration>
                     <source>8</source>
                     <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${maven-spotless-plugin.version}</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat>
+                            <!-- 1.19.1 support JDK21 -->
+                            <version>1.19.1</version>
+                            <style>GOOGLE</style>
+                        </googleJavaFormat>
+                    </java>
+                    <kotlin>
+                        <ktfmt>
+                            <version>0.46</version>
+                            <style>GOOGLE</style>
+                        </ktfmt>
+                    </kotlin>
                 </configuration>
             </plugin>
         </plugins>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -137,6 +137,9 @@
                                 <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
                                 <sourceDir>${project.basedir}/src/main/java</sourceDir>
                             </sourceDirs>
+                            <args>
+                                <arg>-Xexplicit-api=strict</arg> <!-- Enable explicit api mode -->
+                            </args>
                         </configuration>
                     </execution>
                     <execution>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -29,11 +29,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-      <maven.compiler.source>1.8</maven.compiler.source>
-      <maven.compiler.target>1.8</maven.compiler.target>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-      <maven-spotless-plugin.version>2.43.0</maven-spotless-plugin.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+        <maven-spotless-plugin.version>2.43.0</maven-spotless-plugin.version>
+        <kotlin.version>2.0.20</kotlin.version>
     </properties>
 
     <build>
@@ -200,13 +201,13 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-testng</artifactId>
-            <version>2.0.20</version>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>2.0.20</version>
+            <version>${kotlin.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/kotlin/src/main/java/org/apache/fury/serializer/kotlin/KotlinSerializers.java
+++ b/kotlin/src/main/java/org/apache/fury/serializer/kotlin/KotlinSerializers.java
@@ -20,16 +20,15 @@
 package org.apache.fury.serializer.kotlin;
 
 import kotlin.*;
-import kotlin.text.*;
-import kotlin.time.Duration;
-import kotlin.time.DurationUnit;
-import kotlin.time.TestTimeSource;
-import kotlin.time.TimedValue;
-import kotlin.uuid.Uuid;
 import kotlin.UByteArray;
 import kotlin.UIntArray;
 import kotlin.ULongArray;
 import kotlin.UShortArray;
+import kotlin.text.*;
+import kotlin.time.Duration;
+import kotlin.time.DurationUnit;
+import kotlin.time.TimedValue;
+import kotlin.uuid.Uuid;
 import org.apache.fury.AbstractThreadSafeFury;
 import org.apache.fury.Fury;
 import org.apache.fury.ThreadSafeFury;
@@ -37,110 +36,112 @@ import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.serializer.collection.CollectionSerializers;
 import org.apache.fury.serializer.collection.MapSerializers;
 
-/**
- * KotlinSerializers provide default serializers for kotlin.
- */
+/** KotlinSerializers provide default serializers for kotlin. */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class KotlinSerializers {
 
-    public static void registerSerializers(ThreadSafeFury fury) {
-        AbstractThreadSafeFury threadSafeFury = (AbstractThreadSafeFury) fury;
-        threadSafeFury.registerCallback(KotlinSerializers::registerSerializers);
-    }
+  public static void registerSerializers(ThreadSafeFury fury) {
+    AbstractThreadSafeFury threadSafeFury = (AbstractThreadSafeFury) fury;
+    threadSafeFury.registerCallback(KotlinSerializers::registerSerializers);
+  }
 
-    public static void registerSerializers(Fury fury) {
-        ClassResolver resolver = fury.getClassResolver();
+  public static void registerSerializers(Fury fury) {
+    ClassResolver resolver = fury.getClassResolver();
 
-        // UByte
-        Class ubyteClass = KotlinToJavaClass.INSTANCE.getUByteClass();
-        resolver.register(ubyteClass);
-        resolver.registerSerializer(ubyteClass, new UByteSerializer(fury));
+    // UByte
+    Class ubyteClass = KotlinToJavaClass.INSTANCE.getUByteClass();
+    resolver.register(ubyteClass);
+    resolver.registerSerializer(ubyteClass, new UByteSerializer(fury));
 
-        // UShort
-        Class ushortClass = KotlinToJavaClass.INSTANCE.getUShortClass();
-        resolver.register(ushortClass);
-        resolver.registerSerializer(ushortClass, new UShortSerializer(fury));
+    // UShort
+    Class ushortClass = KotlinToJavaClass.INSTANCE.getUShortClass();
+    resolver.register(ushortClass);
+    resolver.registerSerializer(ushortClass, new UShortSerializer(fury));
 
-        // UInt
-        Class uintClass = KotlinToJavaClass.INSTANCE.getUIntClass();
-        resolver.register(uintClass);
-        resolver.registerSerializer(uintClass, new UIntSerializer(fury));
+    // UInt
+    Class uintClass = KotlinToJavaClass.INSTANCE.getUIntClass();
+    resolver.register(uintClass);
+    resolver.registerSerializer(uintClass, new UIntSerializer(fury));
 
-        // ULong
-        Class ulongClass = KotlinToJavaClass.INSTANCE.getULongClass();
-        resolver.register(ulongClass);
-        resolver.registerSerializer(ulongClass, new ULongSerializer(fury));
+    // ULong
+    Class ulongClass = KotlinToJavaClass.INSTANCE.getULongClass();
+    resolver.register(ulongClass);
+    resolver.registerSerializer(ulongClass, new ULongSerializer(fury));
 
-        // EmptyList
-        Class emptyListClass = KotlinToJavaClass.INSTANCE.getEmptyListClass();
-        resolver.register(emptyListClass);
-        resolver.registerSerializer(emptyListClass, new CollectionSerializers.EmptyListSerializer(fury, emptyListClass));
+    // EmptyList
+    Class emptyListClass = KotlinToJavaClass.INSTANCE.getEmptyListClass();
+    resolver.register(emptyListClass);
+    resolver.registerSerializer(
+        emptyListClass, new CollectionSerializers.EmptyListSerializer(fury, emptyListClass));
 
-        // EmptySet
-        Class emptySetClass = KotlinToJavaClass.INSTANCE.getEmptySetClass();
-        resolver.register(emptySetClass);
-        resolver.registerSerializer(emptySetClass, new CollectionSerializers.EmptySetSerializer(fury, emptySetClass));
+    // EmptySet
+    Class emptySetClass = KotlinToJavaClass.INSTANCE.getEmptySetClass();
+    resolver.register(emptySetClass);
+    resolver.registerSerializer(
+        emptySetClass, new CollectionSerializers.EmptySetSerializer(fury, emptySetClass));
 
-        // EmptyMap
-        Class emptyMapClass = KotlinToJavaClass.INSTANCE.getEmptyMapClass();
-        resolver.register(emptyMapClass);
-        resolver.registerSerializer(emptyMapClass, new MapSerializers.EmptyMapSerializer(fury, emptyMapClass));
+    // EmptyMap
+    Class emptyMapClass = KotlinToJavaClass.INSTANCE.getEmptyMapClass();
+    resolver.register(emptyMapClass);
+    resolver.registerSerializer(
+        emptyMapClass, new MapSerializers.EmptyMapSerializer(fury, emptyMapClass));
 
-        // Non-Java collection implementation in kotlin stdlib.
-        Class arrayDequeClass = KotlinToJavaClass.INSTANCE.getArrayDequeClass();
-        resolver.register(arrayDequeClass);
-        resolver.registerSerializer(arrayDequeClass, new KotlinArrayDequeSerializer(fury, arrayDequeClass));
+    // Non-Java collection implementation in kotlin stdlib.
+    Class arrayDequeClass = KotlinToJavaClass.INSTANCE.getArrayDequeClass();
+    resolver.register(arrayDequeClass);
+    resolver.registerSerializer(
+        arrayDequeClass, new KotlinArrayDequeSerializer(fury, arrayDequeClass));
 
-        // Unsigned array classes: UByteArray, UShortArray, UIntArray, ULongArray.
-        resolver.register(UByteArray.class);
-        resolver.registerSerializer(UByteArray.class, new UByteArraySerializer(fury));
-        resolver.register(UShortArray.class);
-        resolver.registerSerializer(UShortArray.class, new UShortArraySerializer(fury));
-        resolver.register(UIntArray.class);
-        resolver.registerSerializer(UIntArray.class, new UIntArraySerializer(fury));
-        resolver.register(ULongArray.class);
-        resolver.registerSerializer(ULongArray.class, new ULongArraySerializer(fury));
+    // Unsigned array classes: UByteArray, UShortArray, UIntArray, ULongArray.
+    resolver.register(UByteArray.class);
+    resolver.registerSerializer(UByteArray.class, new UByteArraySerializer(fury));
+    resolver.register(UShortArray.class);
+    resolver.registerSerializer(UShortArray.class, new UShortArraySerializer(fury));
+    resolver.register(UIntArray.class);
+    resolver.registerSerializer(UIntArray.class, new UIntArraySerializer(fury));
+    resolver.register(ULongArray.class);
+    resolver.registerSerializer(ULongArray.class, new ULongArraySerializer(fury));
 
-        // Ranges and Progressions.
-        resolver.register(kotlin.ranges.CharRange.class);
-        resolver.register(kotlin.ranges.CharProgression.class);
-        resolver.register(kotlin.ranges.IntRange.class);
-        resolver.register(kotlin.ranges.IntProgression.class);
-        resolver.register(kotlin.ranges.LongRange.class);
-        resolver.register(kotlin.ranges.LongProgression.class);
-        resolver.register(kotlin.ranges.UIntRange.class);
-        resolver.register(kotlin.ranges.UIntProgression.class);
-        resolver.register(kotlin.ranges.ULongRange.class);
-        resolver.register(kotlin.ranges.ULongProgression.class);
+    // Ranges and Progressions.
+    resolver.register(kotlin.ranges.CharRange.class);
+    resolver.register(kotlin.ranges.CharProgression.class);
+    resolver.register(kotlin.ranges.IntRange.class);
+    resolver.register(kotlin.ranges.IntProgression.class);
+    resolver.register(kotlin.ranges.LongRange.class);
+    resolver.register(kotlin.ranges.LongProgression.class);
+    resolver.register(kotlin.ranges.UIntRange.class);
+    resolver.register(kotlin.ranges.UIntProgression.class);
+    resolver.register(kotlin.ranges.ULongRange.class);
+    resolver.register(kotlin.ranges.ULongProgression.class);
 
-        // Built-in classes.
-        resolver.register(kotlin.Pair.class);
-        resolver.register(kotlin.Triple.class);
-        resolver.register(kotlin.Result.class);
-        resolver.register(Result.Failure.class);
+    // Built-in classes.
+    resolver.register(kotlin.Pair.class);
+    resolver.register(kotlin.Triple.class);
+    resolver.register(kotlin.Result.class);
+    resolver.register(Result.Failure.class);
 
-        // kotlin.random
-        resolver.register(KotlinToJavaClass.INSTANCE.getRandomDefaultClass());
-        resolver.register(KotlinToJavaClass.INSTANCE.getRandomInternalClass());
-        resolver.register(KotlinToJavaClass.INSTANCE.getRandomSerializedClass());
+    // kotlin.random
+    resolver.register(KotlinToJavaClass.INSTANCE.getRandomDefaultClass());
+    resolver.register(KotlinToJavaClass.INSTANCE.getRandomInternalClass());
+    resolver.register(KotlinToJavaClass.INSTANCE.getRandomSerializedClass());
 
-        // kotlin.text
-        resolver.register(Regex.class);
-        resolver.register(KotlinToJavaClass.INSTANCE.getRegexSerializedClass());
-        resolver.register(RegexOption.class);
-        resolver.register(CharCategory.class);
-        resolver.register(CharDirectionality.class);
-        resolver.register(HexFormat.class);
-        resolver.register(MatchGroup.class);
+    // kotlin.text
+    resolver.register(Regex.class);
+    resolver.register(KotlinToJavaClass.INSTANCE.getRegexSerializedClass());
+    resolver.register(RegexOption.class);
+    resolver.register(CharCategory.class);
+    resolver.register(CharDirectionality.class);
+    resolver.register(HexFormat.class);
+    resolver.register(MatchGroup.class);
 
-        // kotlin.time
-        resolver.register(DurationUnit.class);
-        resolver.register(Duration.class);
-        resolver.registerSerializer(Duration.class, new DurationSerializer(fury));
-        resolver.register(TimedValue.class);
+    // kotlin.time
+    resolver.register(DurationUnit.class);
+    resolver.register(Duration.class);
+    resolver.registerSerializer(Duration.class, new DurationSerializer(fury));
+    resolver.register(TimedValue.class);
 
-        // kotlin.uuid
-        resolver.register(Uuid.class);
-        resolver.registerSerializer(Uuid.class, new UuidSerializer(fury));
-    }
+    // kotlin.uuid
+    resolver.register(Uuid.class);
+    resolver.registerSerializer(Uuid.class, new UuidSerializer(fury));
+  }
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionBuilder.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionBuilder.kt
@@ -22,26 +22,26 @@ package org.apache.fury.serializer.kotlin
 /**
  * Collection builder interface adapts an iterable to allow incremental build by the fury protocol.
  */
-interface CollectionBuilder<E, T : Iterable<E>> {
-  fun add(element: E): Boolean
+public interface CollectionBuilder<E, T : Iterable<E>> {
+  public fun add(element: E): Boolean
 
-  fun result(): T
+  public fun result(): T
 }
 
 /** Abstract builder for [kotlin.collections.List] interface. */
-abstract class AbstractListBuilder<E, T : List<E>> :
+public abstract class AbstractListBuilder<E, T : List<E>> :
   CollectionBuilder<E, T>, AdaptedCollection<E>() {
   protected open val builder: MutableList<E> = mutableListOf()
   override val size: Int
     get() = builder.size
 
-  override fun add(element: E) = builder.add(element)
+  override fun add(element: E): Boolean = builder.add(element)
 
   override fun iterator(): MutableIterator<E> = builder.iterator()
 }
 
 /** Builder for [kotlin.collections.ArrayDeque]. */
-class ArrayDequeBuilder<E>(override val builder: ArrayDeque<E>) :
+public class ArrayDequeBuilder<E>(override val builder: ArrayDeque<E>) :
   AbstractListBuilder<E, ArrayDeque<E>>() {
   override fun result(): ArrayDeque<E> = builder
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionBuilder.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionBuilder.kt
@@ -22,29 +22,26 @@ package org.apache.fury.serializer.kotlin
 /**
  * Collection builder interface adapts an iterable to allow incremental build by the fury protocol.
  */
-interface CollectionBuilder <E, T: Iterable<E>> {
-    fun add(element: E): Boolean
-    fun result(): T
+interface CollectionBuilder<E, T : Iterable<E>> {
+  fun add(element: E): Boolean
+
+  fun result(): T
 }
 
-/**
- * Abstract builder for [kotlin.collections.List] interface.
- */
-abstract class AbstractListBuilder<E, T:List<E>>
-    : CollectionBuilder<E, T>, AdaptedCollection<E>() {
-    protected open val builder: MutableList<E> = mutableListOf()
-    override val size: Int
-        get() = builder.size
-    override fun add(element: E) =
-        builder.add(element)
-    override fun iterator(): MutableIterator<E> = builder.iterator()
+/** Abstract builder for [kotlin.collections.List] interface. */
+abstract class AbstractListBuilder<E, T : List<E>> :
+  CollectionBuilder<E, T>, AdaptedCollection<E>() {
+  protected open val builder: MutableList<E> = mutableListOf()
+  override val size: Int
+    get() = builder.size
+
+  override fun add(element: E) = builder.add(element)
+
+  override fun iterator(): MutableIterator<E> = builder.iterator()
 }
 
-/**
- * Builder for [kotlin.collections.ArrayDeque].
- */
-class ArrayDequeBuilder<E>(
-    override val builder: ArrayDeque<E>
-): AbstractListBuilder<E, ArrayDeque<E>>() {
-    override fun result(): ArrayDeque<E> = builder
+/** Builder for [kotlin.collections.ArrayDeque]. */
+class ArrayDequeBuilder<E>(override val builder: ArrayDeque<E>) :
+  AbstractListBuilder<E, ArrayDeque<E>>() {
+  override fun result(): ArrayDeque<E> = builder
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializer.kt
@@ -25,8 +25,10 @@ import org.apache.fury.serializer.collection.AbstractCollectionSerializer
 
 /** Serializer for kotlin collections. */
 @Suppress("UNCHECKED_CAST")
-public abstract class AbstractKotlinCollectionSerializer<E, T : Iterable<E>>(fury: Fury, cls: Class<T>) :
-  AbstractCollectionSerializer<T>(fury, cls) {
+public abstract class AbstractKotlinCollectionSerializer<E, T : Iterable<E>>(
+  fury: Fury,
+  cls: Class<T>
+) : AbstractCollectionSerializer<T>(fury, cls) {
   abstract override fun onCollectionWrite(buffer: MemoryBuffer, value: T): Collection<E>
 
   override fun read(buffer: MemoryBuffer): T {

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializer.kt
@@ -23,61 +23,51 @@ import org.apache.fury.Fury
 import org.apache.fury.memory.MemoryBuffer
 import org.apache.fury.serializer.collection.AbstractCollectionSerializer
 
-/**
- * Serializer for kotlin collections.
- */
+/** Serializer for kotlin collections. */
 @Suppress("UNCHECKED_CAST")
-abstract class AbstractKotlinCollectionSerializer<E, T: Iterable<E>>(
-    fury: Fury,
-    cls: Class<T>
-) : AbstractCollectionSerializer<T>(fury, cls) {
-    abstract override fun onCollectionWrite(buffer: MemoryBuffer, value: T): Collection<E>
+abstract class AbstractKotlinCollectionSerializer<E, T : Iterable<E>>(fury: Fury, cls: Class<T>) :
+  AbstractCollectionSerializer<T>(fury, cls) {
+  abstract override fun onCollectionWrite(buffer: MemoryBuffer, value: T): Collection<E>
 
-    override fun read(buffer: MemoryBuffer): T {
-        val collection = newCollection(buffer)
-        val numElements = getAndClearNumElements()
-        if (numElements != 0) readElements(fury, buffer, collection, numElements)
-        return onCollectionRead(collection)
-    }
+  override fun read(buffer: MemoryBuffer): T {
+    val collection = newCollection(buffer)
+    val numElements = getAndClearNumElements()
+    if (numElements != 0) readElements(fury, buffer, collection, numElements)
+    return onCollectionRead(collection)
+  }
 
-    override fun onCollectionRead(collection: Collection<*>): T {
-        val builder = collection as CollectionBuilder<E, T>
-        return builder.result()
-    }
+  override fun onCollectionRead(collection: Collection<*>): T {
+    val builder = collection as CollectionBuilder<E, T>
+    return builder.result()
+  }
 }
 
-/**
- * Serializer for [[kotlin.collections.ArrayDeque]].
- */
-class KotlinArrayDequeSerializer<E> (
-    fury: Fury,
-    cls: Class<ArrayDeque<E>>,
+/** Serializer for [[kotlin.collections.ArrayDeque]]. */
+class KotlinArrayDequeSerializer<E>(
+  fury: Fury,
+  cls: Class<ArrayDeque<E>>,
 ) : AbstractKotlinCollectionSerializer<E, ArrayDeque<E>>(fury, cls) {
-    override fun onCollectionWrite(buffer: MemoryBuffer, value: ArrayDeque<E>): Collection<E> {
-        val adapter = IterableAdapter<E>(value)
-        buffer.writeVarUint32Small7(adapter.size)
-        return adapter
-    }
-    override fun newCollection(buffer: MemoryBuffer): Collection<E> {
-        val numElements = buffer.readVarUint32()
-        setNumElements(numElements)
-        return ArrayDequeBuilder<E>(ArrayDeque<E>(numElements))
-    }
+  override fun onCollectionWrite(buffer: MemoryBuffer, value: ArrayDeque<E>): Collection<E> {
+    val adapter = IterableAdapter<E>(value)
+    buffer.writeVarUint32Small7(adapter.size)
+    return adapter
+  }
+
+  override fun newCollection(buffer: MemoryBuffer): Collection<E> {
+    val numElements = buffer.readVarUint32()
+    setNumElements(numElements)
+    return ArrayDequeBuilder<E>(ArrayDeque<E>(numElements))
+  }
 }
 
 typealias AdaptedCollection<E> = java.util.AbstractCollection<E>
 
-/**
- * An adapter which wraps a kotlin iterable into a [[java.util.Collection]].
- */
-private class IterableAdapter<E>(
-    coll: Iterable<E>
-) : AdaptedCollection<E>() {
-    private val mutableList = coll.toMutableList()
+/** An adapter which wraps a kotlin iterable into a [[java.util.Collection]]. */
+private class IterableAdapter<E>(coll: Iterable<E>) : AdaptedCollection<E>() {
+  private val mutableList = coll.toMutableList()
 
-    override val size: Int
-        get() = mutableList.count()
+  override val size: Int
+    get() = mutableList.count()
 
-    override fun iterator(): MutableIterator<E> =
-        mutableList.iterator()
+  override fun iterator(): MutableIterator<E> = mutableList.iterator()
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializer.kt
@@ -25,7 +25,7 @@ import org.apache.fury.serializer.collection.AbstractCollectionSerializer
 
 /** Serializer for kotlin collections. */
 @Suppress("UNCHECKED_CAST")
-abstract class AbstractKotlinCollectionSerializer<E, T : Iterable<E>>(fury: Fury, cls: Class<T>) :
+public abstract class AbstractKotlinCollectionSerializer<E, T : Iterable<E>>(fury: Fury, cls: Class<T>) :
   AbstractCollectionSerializer<T>(fury, cls) {
   abstract override fun onCollectionWrite(buffer: MemoryBuffer, value: T): Collection<E>
 
@@ -43,7 +43,7 @@ abstract class AbstractKotlinCollectionSerializer<E, T : Iterable<E>>(fury: Fury
 }
 
 /** Serializer for [[kotlin.collections.ArrayDeque]]. */
-class KotlinArrayDequeSerializer<E>(
+public class KotlinArrayDequeSerializer<E>(
   fury: Fury,
   cls: Class<ArrayDeque<E>>,
 ) : AbstractKotlinCollectionSerializer<E, ArrayDeque<E>>(fury, cls) {
@@ -60,7 +60,7 @@ class KotlinArrayDequeSerializer<E>(
   }
 }
 
-typealias AdaptedCollection<E> = java.util.AbstractCollection<E>
+public typealias AdaptedCollection<E> = java.util.AbstractCollection<E>
 
 /** An adapter which wraps a kotlin iterable into a [[java.util.Collection]]. */
 private class IterableAdapter<E>(coll: Iterable<E>) : AdaptedCollection<E>() {

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/DurationSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/DurationSerializer.kt
@@ -33,10 +33,10 @@ import org.apache.fury.memory.MemoryBuffer
 import org.apache.fury.serializer.ImmutableSerializer
 import org.apache.fury.serializer.Serializer
 
-class DurationSerializer(fury: Fury, needToWriteRef: Boolean) :
+public class DurationSerializer(fury: Fury, needToWriteRef: Boolean) :
   ImmutableSerializer<Duration>(fury, Duration::class.java, needToWriteRef) {
 
-  constructor(
+  public constructor(
     fury: Fury,
   ) : this(fury, fury.config.isTimeRefIgnored)
 

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/DurationSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/DurationSerializer.kt
@@ -19,10 +19,6 @@
 
 package org.apache.fury.serializer.kotlin
 
-import org.apache.fury.Fury
-import org.apache.fury.memory.MemoryBuffer
-import org.apache.fury.serializer.ImmutableSerializer
-import org.apache.fury.serializer.Serializer
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -32,90 +28,90 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
+import org.apache.fury.Fury
+import org.apache.fury.memory.MemoryBuffer
+import org.apache.fury.serializer.ImmutableSerializer
+import org.apache.fury.serializer.Serializer
 
-class DurationSerializer(
+class DurationSerializer(fury: Fury, needToWriteRef: Boolean) :
+  ImmutableSerializer<Duration>(fury, Duration::class.java, needToWriteRef) {
+
+  constructor(
     fury: Fury,
-    needToWriteRef:Boolean
-) : ImmutableSerializer<Duration>(
-    fury,
-    Duration::class.java,
-    needToWriteRef) {
+  ) : this(fury, fury.config.isTimeRefIgnored)
 
-    constructor(
-        fury: Fury,
-    ) : this (fury, fury.config.isTimeRefIgnored)
+  private val durationUnitSerializer: Serializer<DurationUnit> by lazy {
+    fury.classResolver.getSerializer(DurationUnit::class.java)
+  }
 
-    private val durationUnitSerializer: Serializer<DurationUnit> by lazy {
-        fury.classResolver.getSerializer(DurationUnit::class.java)
+  override fun write(buffer: MemoryBuffer, value: Duration) {
+    val unit = computeDurationUnitPrecision(value)
+    durationUnitSerializer.write(buffer, unit)
+
+    val rawValue: Long =
+      when (unit) {
+        DurationUnit.NANOSECONDS -> value.inWholeNanoseconds
+        DurationUnit.MICROSECONDS -> value.inWholeMicroseconds
+        DurationUnit.MILLISECONDS -> value.inWholeMilliseconds
+        DurationUnit.SECONDS -> value.inWholeSeconds
+        DurationUnit.MINUTES -> value.inWholeMinutes
+        DurationUnit.HOURS -> value.inWholeHours
+        DurationUnit.DAYS -> value.inWholeDays
+      }
+
+    buffer.writeInt64(rawValue)
+  }
+
+  override fun read(buffer: MemoryBuffer): Duration {
+    val unit = durationUnitSerializer.read(buffer)
+    val rawValue = buffer.readInt64()
+    return when (unit) {
+      DurationUnit.NANOSECONDS -> rawValue.nanoseconds
+      DurationUnit.MICROSECONDS -> rawValue.microseconds
+      DurationUnit.MILLISECONDS -> rawValue.milliseconds
+      DurationUnit.SECONDS -> rawValue.seconds
+      DurationUnit.MINUTES -> rawValue.minutes
+      DurationUnit.HOURS -> rawValue.hours
+      DurationUnit.DAYS -> rawValue.days
+    }
+  }
+
+  private fun computeDurationUnitPrecision(value: Duration): DurationUnit {
+    if (value == Duration.ZERO) {
+      return DurationUnit.NANOSECONDS
+    }
+    if (value.isInfinite()) {
+      return DurationUnit.MILLISECONDS
     }
 
-    override fun write(buffer: MemoryBuffer, value: Duration) {
-        val unit = computeDurationUnitPrecision(value)
-        durationUnitSerializer.write(buffer, unit)
+    value.absoluteValue.toComponents { days, hours, minutes, seconds, nanoseconds ->
+      val millisecondPrecision = nanoseconds >= 1_000_000 && nanoseconds % 1_000_000 == 0
+      if (millisecondPrecision) {
+        return DurationUnit.MILLISECONDS
+      }
+      val microsecondPrecision = nanoseconds >= 1_000 && nanoseconds % 1_000 == 0
+      if (microsecondPrecision) {
+        return DurationUnit.MICROSECONDS
+      }
+      val nanoSecondPrecision = nanoseconds != 0 && nanoseconds % 1000 != 0
+      if (nanoSecondPrecision) {
+        return DurationUnit.NANOSECONDS
+      }
 
-        val rawValue: Long = when (unit) {
-            DurationUnit.NANOSECONDS -> value.inWholeNanoseconds
-            DurationUnit.MICROSECONDS -> value.inWholeMicroseconds
-            DurationUnit.MILLISECONDS -> value.inWholeMilliseconds
-            DurationUnit.SECONDS -> value.inWholeSeconds
-            DurationUnit.MINUTES -> value.inWholeMinutes
-            DurationUnit.HOURS -> value.inWholeHours
-            DurationUnit.DAYS -> value.inWholeDays
-        }
+      if (seconds != 0) {
+        return DurationUnit.SECONDS
+      }
 
-        buffer.writeInt64(rawValue)
+      if (minutes != 0) {
+        return DurationUnit.MINUTES
+      }
+
+      if (hours != 0) {
+        return DurationUnit.HOURS
+      }
+
+      // Return lowest precision unit.
+      return DurationUnit.DAYS
     }
-
-    override fun read(buffer: MemoryBuffer): Duration {
-        val unit = durationUnitSerializer.read(buffer)
-        val rawValue = buffer.readInt64()
-        return when (unit) {
-                DurationUnit.NANOSECONDS -> rawValue.nanoseconds
-                DurationUnit.MICROSECONDS -> rawValue.microseconds
-                DurationUnit.MILLISECONDS -> rawValue.milliseconds
-                DurationUnit.SECONDS -> rawValue.seconds
-                DurationUnit.MINUTES -> rawValue.minutes
-                DurationUnit.HOURS -> rawValue.hours
-                DurationUnit.DAYS -> rawValue.days
-            }
-    }
-
-    private fun computeDurationUnitPrecision(value:Duration) :DurationUnit {
-        if (value == Duration.ZERO) {
-            return DurationUnit.NANOSECONDS
-        }
-        if (value.isInfinite()) {
-            return DurationUnit.MILLISECONDS
-        }
-
-        value.absoluteValue.toComponents { days, hours, minutes, seconds, nanoseconds ->
-            val millisecondPrecision = nanoseconds >= 1_000_000 && nanoseconds % 1_000_000 == 0
-            if (millisecondPrecision) {
-                return DurationUnit.MILLISECONDS
-            }
-            val microsecondPrecision= nanoseconds >= 1_000 && nanoseconds % 1_000 == 0
-            if (microsecondPrecision) {
-                return DurationUnit.MICROSECONDS
-            }
-            val nanoSecondPrecision= nanoseconds != 0 && nanoseconds % 1000 != 0
-            if (nanoSecondPrecision) {
-                return DurationUnit.NANOSECONDS
-            }
-
-            if (seconds != 0) {
-                return DurationUnit.SECONDS
-            }
-
-            if (minutes != 0) {
-                return DurationUnit.MINUTES
-            }
-
-            if (hours != 0) {
-                return DurationUnit.HOURS
-            }
-
-            // Return lowest precision unit.
-            return DurationUnit.DAYS
-        }
-    }
+  }
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/KotlinToJavaClass.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/KotlinToJavaClass.kt
@@ -21,7 +21,7 @@ package org.apache.fury.serializer.kotlin
 
 import kotlin.random.Random
 
-object KotlinToJavaClass {
+internal object KotlinToJavaClass {
   // Collections
   val ArrayDequeClass = ArrayDeque::class.java
   val EmptyListClass = emptyList<Any>().javaClass

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/KotlinToJavaClass.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/KotlinToJavaClass.kt
@@ -22,23 +22,23 @@ package org.apache.fury.serializer.kotlin
 import kotlin.random.Random
 
 object KotlinToJavaClass {
-    // Collections
-    val ArrayDequeClass = ArrayDeque::class.java
-    val EmptyListClass = emptyList<Any>().javaClass
-    val EmptySetClass = emptySet<Any>().javaClass
-    val EmptyMapClass = emptyMap<Any, Any>().javaClass
+  // Collections
+  val ArrayDequeClass = ArrayDeque::class.java
+  val EmptyListClass = emptyList<Any>().javaClass
+  val EmptySetClass = emptySet<Any>().javaClass
+  val EmptyMapClass = emptyMap<Any, Any>().javaClass
 
-    // Unsigned
-    val UByteClass = UByte::class.java
-    val UShortClass = UShort::class.java
-    val UIntClass = UInt::class.java
-    val ULongClass = ULong::class.java
+  // Unsigned
+  val UByteClass = UByte::class.java
+  val UShortClass = UShort::class.java
+  val UIntClass = UInt::class.java
+  val ULongClass = ULong::class.java
 
-    // Random
-    val RandomInternalClass = Random(1)::class.java
-    val RandomDefaultClass = Random.Default::class.java
-    val RandomSerializedClass = Class.forName("kotlin.random.Random\$Default\$Serialized")
+  // Random
+  val RandomInternalClass = Random(1)::class.java
+  val RandomDefaultClass = Random.Default::class.java
+  val RandomSerializedClass = Class.forName("kotlin.random.Random\$Default\$Serialized")
 
-    // Regex
-    val RegexSerializedClass = Class.forName("kotlin.text.Regex\$Serialized")
+  // Regex
+  val RegexSerializedClass = Class.forName("kotlin.text.Regex\$Serialized")
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedArraySerializers.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedArraySerializers.kt
@@ -26,7 +26,7 @@ import org.apache.fury.memory.MemoryBuffer
 import org.apache.fury.serializer.Serializer
 import org.apache.fury.type.Type
 
-abstract class AbstractDelegatingArraySerializer<T, T_Delegate>(
+public abstract class AbstractDelegatingArraySerializer<T, T_Delegate>(
   fury: Fury,
   cls: Class<T>,
   private val delegateClass: Class<T_Delegate>
@@ -35,9 +35,9 @@ abstract class AbstractDelegatingArraySerializer<T, T_Delegate>(
   // Lazily initialize the delegatingSerializer here to avoid lookup cost.
   private val delegatingSerializer by lazy { fury.classResolver.getSerializer(delegateClass) }
 
-  abstract fun toDelegateClass(value: T): T_Delegate
+  protected abstract fun toDelegateClass(value: T): T_Delegate
 
-  abstract fun fromDelegateClass(value: T_Delegate): T
+  protected abstract fun fromDelegateClass(value: T_Delegate): T
 
   override fun getXtypeId(): Short {
     return (-Type.LIST.id).toShort()
@@ -61,7 +61,7 @@ abstract class AbstractDelegatingArraySerializer<T, T_Delegate>(
   }
 }
 
-class UByteArraySerializer(
+public class UByteArraySerializer(
   fury: Fury,
 ) :
   AbstractDelegatingArraySerializer<UByteArray, ByteArray>(
@@ -69,14 +69,14 @@ class UByteArraySerializer(
     UByteArray::class.java,
     ByteArray::class.java
   ) {
-  override fun toDelegateClass(value: UByteArray) = value.toByteArray()
+  override fun toDelegateClass(value: UByteArray): ByteArray = value.toByteArray()
 
-  override fun fromDelegateClass(value: ByteArray) = value.toUByteArray()
+  override fun fromDelegateClass(value: ByteArray): UByteArray = value.toUByteArray()
 
   override fun copy(value: UByteArray): UByteArray = value.copyOf()
 }
 
-class UShortArraySerializer(
+public class UShortArraySerializer(
   fury: Fury,
 ) :
   AbstractDelegatingArraySerializer<UShortArray, ShortArray>(
@@ -84,14 +84,14 @@ class UShortArraySerializer(
     UShortArray::class.java,
     ShortArray::class.java
   ) {
-  override fun toDelegateClass(value: UShortArray) = value.toShortArray()
+  override fun toDelegateClass(value: UShortArray): ShortArray = value.toShortArray()
 
-  override fun fromDelegateClass(value: ShortArray) = value.toUShortArray()
+  override fun fromDelegateClass(value: ShortArray): UShortArray = value.toUShortArray()
 
-  override fun copy(value: UShortArray) = value.copyOf()
+  override fun copy(value: UShortArray): UShortArray = value.copyOf()
 }
 
-class UIntArraySerializer(
+public class UIntArraySerializer(
   fury: Fury,
 ) :
   AbstractDelegatingArraySerializer<UIntArray, IntArray>(
@@ -99,14 +99,14 @@ class UIntArraySerializer(
     UIntArray::class.java,
     IntArray::class.java
   ) {
-  override fun toDelegateClass(value: UIntArray) = value.toIntArray()
+  override fun toDelegateClass(value: UIntArray): IntArray = value.toIntArray()
 
-  override fun fromDelegateClass(value: IntArray) = value.toUIntArray()
+  override fun fromDelegateClass(value: IntArray): UIntArray = value.toUIntArray()
 
-  override fun copy(value: UIntArray) = value.copyOf()
+  override fun copy(value: UIntArray): UIntArray = value.copyOf()
 }
 
-class ULongArraySerializer(
+public class ULongArraySerializer(
   fury: Fury,
 ) :
   AbstractDelegatingArraySerializer<ULongArray, LongArray>(
@@ -114,9 +114,9 @@ class ULongArraySerializer(
     ULongArray::class.java,
     LongArray::class.java
   ) {
-  override fun toDelegateClass(value: ULongArray) = value.toLongArray()
+  override fun toDelegateClass(value: ULongArray): LongArray = value.toLongArray()
 
-  override fun fromDelegateClass(value: LongArray) = value.toULongArray()
+  override fun fromDelegateClass(value: LongArray): ULongArray = value.toULongArray()
 
-  override fun copy(value: ULongArray) = value.copyOf()
+  override fun copy(value: ULongArray): ULongArray = value.copyOf()
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedArraySerializers.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedArraySerializers.kt
@@ -27,86 +27,96 @@ import org.apache.fury.serializer.Serializer
 import org.apache.fury.type.Type
 
 abstract class AbstractDelegatingArraySerializer<T, T_Delegate>(
-    fury: Fury,
-    cls: Class<T>,
-    private val delegateClass: Class<T_Delegate>
-) : Serializer<T> (fury, cls) {
+  fury: Fury,
+  cls: Class<T>,
+  private val delegateClass: Class<T_Delegate>
+) : Serializer<T>(fury, cls) {
 
-    // Lazily initialize the delegatingSerializer here to avoid lookup cost.
-    private val delegatingSerializer by lazy {
-        fury.classResolver.getSerializer(delegateClass)
-    }
+  // Lazily initialize the delegatingSerializer here to avoid lookup cost.
+  private val delegatingSerializer by lazy { fury.classResolver.getSerializer(delegateClass) }
 
-    abstract fun toDelegateClass(value: T): T_Delegate
+  abstract fun toDelegateClass(value: T): T_Delegate
 
-    abstract fun fromDelegateClass(value: T_Delegate): T
+  abstract fun fromDelegateClass(value: T_Delegate): T
 
-    override fun getXtypeId(): Short {
-        return (-Type.LIST.id).toShort()
-    }
+  override fun getXtypeId(): Short {
+    return (-Type.LIST.id).toShort()
+  }
 
-    override fun xwrite(buffer: MemoryBuffer, value: T) {
-        write(buffer, value)
-    }
+  override fun xwrite(buffer: MemoryBuffer, value: T) {
+    write(buffer, value)
+  }
 
-    override fun xread(buffer: MemoryBuffer): T {
-        return read(buffer)
-    }
+  override fun xread(buffer: MemoryBuffer): T {
+    return read(buffer)
+  }
 
-    override fun write(buffer: MemoryBuffer, value: T) {
-        delegatingSerializer.write(buffer, toDelegateClass(value))
-    }
+  override fun write(buffer: MemoryBuffer, value: T) {
+    delegatingSerializer.write(buffer, toDelegateClass(value))
+  }
 
-    override fun read(buffer: MemoryBuffer): T {
-        val delegatedValue = delegatingSerializer.read(buffer)
-        return fromDelegateClass(delegatedValue)
-    }
+  override fun read(buffer: MemoryBuffer): T {
+    val delegatedValue = delegatingSerializer.read(buffer)
+    return fromDelegateClass(delegatedValue)
+  }
 }
 
 class UByteArraySerializer(
-    fury: Fury,
-)  : AbstractDelegatingArraySerializer<UByteArray, ByteArray>(
+  fury: Fury,
+) :
+  AbstractDelegatingArraySerializer<UByteArray, ByteArray>(
     fury,
     UByteArray::class.java,
     ByteArray::class.java
-) {
-    override fun toDelegateClass(value: UByteArray) = value.toByteArray()
-    override fun fromDelegateClass(value: ByteArray) = value.toUByteArray()
-    override fun copy(value: UByteArray): UByteArray = value.copyOf()
+  ) {
+  override fun toDelegateClass(value: UByteArray) = value.toByteArray()
+
+  override fun fromDelegateClass(value: ByteArray) = value.toUByteArray()
+
+  override fun copy(value: UByteArray): UByteArray = value.copyOf()
 }
 
 class UShortArraySerializer(
-    fury: Fury,
-)  : AbstractDelegatingArraySerializer<UShortArray, ShortArray>(
+  fury: Fury,
+) :
+  AbstractDelegatingArraySerializer<UShortArray, ShortArray>(
     fury,
     UShortArray::class.java,
     ShortArray::class.java
-) {
-    override fun toDelegateClass(value: UShortArray) = value.toShortArray()
-    override fun fromDelegateClass(value: ShortArray) = value.toUShortArray()
-    override fun copy(value: UShortArray) = value.copyOf()
+  ) {
+  override fun toDelegateClass(value: UShortArray) = value.toShortArray()
+
+  override fun fromDelegateClass(value: ShortArray) = value.toUShortArray()
+
+  override fun copy(value: UShortArray) = value.copyOf()
 }
 
 class UIntArraySerializer(
-    fury: Fury,
-)  : AbstractDelegatingArraySerializer<UIntArray, IntArray>(
+  fury: Fury,
+) :
+  AbstractDelegatingArraySerializer<UIntArray, IntArray>(
     fury,
     UIntArray::class.java,
     IntArray::class.java
-) {
-    override fun toDelegateClass(value: UIntArray) = value.toIntArray()
-    override fun fromDelegateClass(value: IntArray) = value.toUIntArray()
-    override fun copy(value: UIntArray) = value.copyOf()
+  ) {
+  override fun toDelegateClass(value: UIntArray) = value.toIntArray()
+
+  override fun fromDelegateClass(value: IntArray) = value.toUIntArray()
+
+  override fun copy(value: UIntArray) = value.copyOf()
 }
 
 class ULongArraySerializer(
-    fury: Fury,
-)  : AbstractDelegatingArraySerializer<ULongArray, LongArray>(
+  fury: Fury,
+) :
+  AbstractDelegatingArraySerializer<ULongArray, LongArray>(
     fury,
     ULongArray::class.java,
     LongArray::class.java
-) {
-    override fun toDelegateClass(value: ULongArray) = value.toLongArray()
-    override fun fromDelegateClass(value: LongArray) = value.toULongArray()
-    override fun copy(value: ULongArray) = value.copyOf()
+  ) {
+  override fun toDelegateClass(value: ULongArray) = value.toLongArray()
+
+  override fun fromDelegateClass(value: LongArray) = value.toULongArray()
+
+  override fun copy(value: ULongArray) = value.copyOf()
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -29,7 +29,7 @@ import org.apache.fury.type.Type
  *
  * UByte is mapped to Type.UINT8
  */
-class UByteSerializer(
+public class UByteSerializer(
   fury: Fury,
 ) :
   Serializers.CrossLanguageCompatibleSerializer<UByte>(
@@ -54,7 +54,7 @@ class UByteSerializer(
  *
  * UShort is mapped to Type.UINT16.
  */
-class UShortSerializer(
+public class UShortSerializer(
   fury: Fury,
 ) :
   Serializers.CrossLanguageCompatibleSerializer<UShort>(
@@ -78,7 +78,7 @@ class UShortSerializer(
  *
  * UInt is mapped to Type.UINT32.
  */
-class UIntSerializer(
+public class UIntSerializer(
   fury: Fury,
 ) :
   Serializers.CrossLanguageCompatibleSerializer<UInt>(
@@ -103,7 +103,7 @@ class UIntSerializer(
  *
  * ULong is mapped to Type.UINT64.
  */
-class ULongSerializer(
+public class ULongSerializer(
   fury: Fury,
 ) :
   Serializers.CrossLanguageCompatibleSerializer<ULong>(

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UnsignedSerializer.kt
@@ -28,93 +28,96 @@ import org.apache.fury.type.Type
  * UByteSerializer
  *
  * UByte is mapped to Type.UINT8
- *
  */
 class UByteSerializer(
-    fury: Fury,
-) : Serializers.CrossLanguageCompatibleSerializer<UByte>(
+  fury: Fury,
+) :
+  Serializers.CrossLanguageCompatibleSerializer<UByte>(
     fury,
     UByte::class.java,
     Type.UINT8.id,
     fury.isBasicTypesRefIgnored,
-    true) {
+    true
+  ) {
 
-    override fun write(buffer: MemoryBuffer, value: UByte) {
-        buffer.writeByte(value.toInt())
-    }
+  override fun write(buffer: MemoryBuffer, value: UByte) {
+    buffer.writeByte(value.toInt())
+  }
 
-    override fun read(buffer: MemoryBuffer): UByte {
-        return buffer.readByte().toUByte()
-    }
+  override fun read(buffer: MemoryBuffer): UByte {
+    return buffer.readByte().toUByte()
+  }
 }
-
 
 /**
  * UShortSerializer
  *
  * UShort is mapped to Type.UINT16.
- *
  */
 class UShortSerializer(
-    fury: Fury,
-) : Serializers.CrossLanguageCompatibleSerializer<UShort>(
+  fury: Fury,
+) :
+  Serializers.CrossLanguageCompatibleSerializer<UShort>(
     fury,
     UShort::class.java,
     Type.UINT16.id,
     fury.isBasicTypesRefIgnored,
     true
-) {
-    override fun write(buffer: MemoryBuffer, value: UShort) {
-        buffer.writeVarUint32(value.toInt())
-    }
-    override fun read(buffer: MemoryBuffer): UShort {
-        return buffer.readVarUint32().toUShort()
-    }
+  ) {
+  override fun write(buffer: MemoryBuffer, value: UShort) {
+    buffer.writeVarUint32(value.toInt())
+  }
+
+  override fun read(buffer: MemoryBuffer): UShort {
+    return buffer.readVarUint32().toUShort()
+  }
 }
 
 /**
  * UInt Serializer
  *
  * UInt is mapped to Type.UINT32.
- *
  */
 class UIntSerializer(
-    fury: Fury,
-) : Serializers.CrossLanguageCompatibleSerializer<UInt>(
+  fury: Fury,
+) :
+  Serializers.CrossLanguageCompatibleSerializer<UInt>(
     fury,
     UInt::class.java,
     Type.UINT32.id,
     fury.isBasicTypesRefIgnored,
-    true) {
+    true
+  ) {
 
-    override fun write(buffer: MemoryBuffer, value: UInt) {
-        buffer.writeVarUint32(value.toInt())
-    }
+  override fun write(buffer: MemoryBuffer, value: UInt) {
+    buffer.writeVarUint32(value.toInt())
+  }
 
-    override fun read(buffer: MemoryBuffer): UInt {
-        return buffer.readVarUint32().toUInt()
-    }
+  override fun read(buffer: MemoryBuffer): UInt {
+    return buffer.readVarUint32().toUInt()
+  }
 }
 
 /**
  * ULong Serializer
  *
  * ULong is mapped to Type.UINT64.
- *
  */
 class ULongSerializer(
-    fury: Fury,
-) : Serializers.CrossLanguageCompatibleSerializer<ULong>(
+  fury: Fury,
+) :
+  Serializers.CrossLanguageCompatibleSerializer<ULong>(
     fury,
     ULong::class.java,
     Type.UINT64.id,
     fury.isBasicTypesRefIgnored,
     true
-) {
-    override fun write(buffer: MemoryBuffer, value: ULong) {
-        buffer.writeVarUint64(value.toLong())
-    }
-    override fun read(buffer: MemoryBuffer): ULong {
-        return buffer.readVarUint64().toULong()
-    }
+  ) {
+  override fun write(buffer: MemoryBuffer, value: ULong) {
+    buffer.writeVarUint64(value.toLong())
+  }
+
+  override fun read(buffer: MemoryBuffer): ULong {
+    return buffer.readVarUint64().toULong()
+  }
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UuidSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UuidSerializer.kt
@@ -19,24 +19,22 @@
 
 package org.apache.fury.serializer.kotlin
 
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import org.apache.fury.Fury
 import org.apache.fury.memory.MemoryBuffer
 import org.apache.fury.serializer.ImmutableSerializer
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalUuidApi::class)
-class UuidSerializer(
-    fury: Fury
-) : ImmutableSerializer<Uuid>(fury, Uuid::class.java) {
-    override fun write(buffer: MemoryBuffer, value: Uuid) {
-        value.toLongs { msb, lsb ->
-            buffer.writeInt64(msb)
-            buffer.writeInt64(lsb)
-        }
+class UuidSerializer(fury: Fury) : ImmutableSerializer<Uuid>(fury, Uuid::class.java) {
+  override fun write(buffer: MemoryBuffer, value: Uuid) {
+    value.toLongs { msb, lsb ->
+      buffer.writeInt64(msb)
+      buffer.writeInt64(lsb)
     }
+  }
 
-    override fun read(buffer: MemoryBuffer): Uuid {
-        return Uuid.fromLongs(buffer.readInt64(), buffer.readInt64())
-    }
+  override fun read(buffer: MemoryBuffer): Uuid {
+    return Uuid.fromLongs(buffer.readInt64(), buffer.readInt64())
+  }
 }

--- a/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UuidSerializer.kt
+++ b/kotlin/src/main/kotlin/org/apache/fury/serializer/kotlin/UuidSerializer.kt
@@ -26,7 +26,7 @@ import org.apache.fury.memory.MemoryBuffer
 import org.apache.fury.serializer.ImmutableSerializer
 
 @OptIn(ExperimentalUuidApi::class)
-class UuidSerializer(fury: Fury) : ImmutableSerializer<Uuid>(fury, Uuid::class.java) {
+public class UuidSerializer(fury: Fury) : ImmutableSerializer<Uuid>(fury, Uuid::class.java) {
   override fun write(buffer: MemoryBuffer, value: Uuid) {
     value.toLongs { msb, lsb ->
       buffer.writeInt64(msb)

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/ArraySerializerTest.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/ArraySerializerTest.kt
@@ -26,195 +26,163 @@ import org.testng.annotations.Test
 
 @OptIn(ExperimentalUnsignedTypes::class)
 class ArraySerializerTest {
-    @Test
-    fun testSimpleArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSimpleArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val array = arrayOf("Apple", "Banana", "Orange", "Pineapple")
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+    val array = arrayOf("Apple", "Banana", "Orange", "Pineapple")
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-    @Test
-    fun testMultidimensional() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testMultidimensional() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val array = Array(2) {Array<Int>(2){0} }
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+    val array = Array(2) { Array<Int>(2) { 0 } }
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-    @Test
-    fun testAnyArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testAnyArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
+    val array = arrayOf<Any?>("Apple", 1, null, 3.141, 1.2f)
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = arrayOf<Any?>("Apple", 1, null, 3.141, 1.2f)
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testEmptyArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testEmptyArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = emptyArray<Any?>()
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = emptyArray<Any?>()
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testBooleanArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testBooleanArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = booleanArrayOf(true, false)
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = booleanArrayOf(true, false)
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testByteArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testByteArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = byteArrayOf(0xFF.toByte(), 0xCA.toByte(), 0xFF.toByte())
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = byteArrayOf(0xFF.toByte(), 0xCA.toByte(), 0xFF.toByte())
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testCharArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testCharArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = charArrayOf('a', 'b', 'c')
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = charArrayOf('a', 'b', 'c')
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testDoubleArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testDoubleArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = doubleArrayOf(1.0, 2.0, 3.0)
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = doubleArrayOf(1.0, 2.0, 3.0)
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testFloatArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testFloatArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = floatArrayOf(1.0f, 2.0f)
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = floatArrayOf(1.0f, 2.0f)
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testIntArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testIntArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = intArrayOf(1, 2, 3)
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = intArrayOf(1, 2, 3)
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testLongArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testLongArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = longArrayOf(1L, 2L, 3L)
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = longArrayOf(1L, 2L, 3L)
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testShortArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testShortArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = shortArrayOf(1, 2, 3)
+    assertEquals(array, fury.deserialize(fury.serialize(array)))
+  }
 
-        val array = shortArrayOf(1, 2, 3)
-        assertEquals(array, fury.deserialize(fury.serialize(array)))
-    }
+  @Test
+  fun testUByteArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testUByteArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = ubyteArrayOf(0xFFu, 0xEFu, 0x00u)
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UByteArray))
+  }
 
-        val array = ubyteArrayOf(0xFFu, 0xEFu, 0x00u)
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UByteArray))
-    }
+  @Test
+  fun testUShortArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testUShortArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = ushortArrayOf(1u, 2u)
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UShortArray))
+  }
 
-        val array = ushortArrayOf(1u, 2u)
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UShortArray))
-    }
+  @Test
+  fun testUIntArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testUIntArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+    val array = uintArrayOf(1u, 2u)
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UIntArray))
+  }
 
-        val array = uintArrayOf(1u, 2u)
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UIntArray))
-    }
-    @Test
-    fun testULongArray() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testULongArray() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val array = ulongArrayOf(1u, 2u, 3u)
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as ULongArray))
-    }
+    val array = ulongArrayOf(1u, 2u, 3u)
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as ULongArray))
+  }
 }

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/BuiltinClassSerializerTests.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/BuiltinClassSerializerTests.kt
@@ -19,11 +19,6 @@
 
 package org.apache.fury.serializer.kotlin
 
-import org.apache.fury.Fury
-import org.apache.fury.config.Language
-import org.testng.Assert
-import java.util.UUID
-import kotlin.collections.MutableMap.MutableEntry
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.time.Duration
@@ -36,197 +31,201 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
+import org.apache.fury.Fury
+import org.apache.fury.config.Language
+import org.testng.Assert
 
 class BuiltinClassSerializerTests {
-    @Test
-    fun testSerializePair() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializePair() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value = Pair(1, "one")
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value = Pair(1, "one")
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeTriple() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeTriple() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value = Triple(1, "one", null)
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value = Triple(1, "one", null)
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Suppress("UNCHECKED_CAST")
-    @Test
-    fun testSerializeResult() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .withRefTracking(true)
-            .build()
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun testSerializeResult() {
+    val fury: Fury =
+      Fury.builder()
+        .withLanguage(Language.JAVA)
+        .requireClassRegistration(true)
+        .withRefTracking(true)
+        .build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value1 = Result.success(5)
-        Assert.assertEquals(value1, fury.deserialize(fury.serialize(value1)))
+    KotlinSerializers.registerSerializers(fury)
+    val value1 = Result.success(5)
+    Assert.assertEquals(value1, fury.deserialize(fury.serialize(value1)))
 
-        val value2 = Result.failure<Int>(IllegalStateException("my exception"))
-        val roundtrip = fury.deserialize(fury.serialize(value2)) as Result<Int>
-        Assert.assertTrue(roundtrip.isFailure)
-        Assert.assertEquals(roundtrip.exceptionOrNull()!!.message, "my exception")
-    }
+    val value2 = Result.failure<Int>(IllegalStateException("my exception"))
+    val roundtrip = fury.deserialize(fury.serialize(value2)) as Result<Int>
+    Assert.assertTrue(roundtrip.isFailure)
+    Assert.assertEquals(roundtrip.exceptionOrNull()!!.message, "my exception")
+  }
 
-    @Test
-    fun testSerializeRanges() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .withRefTracking(true)
-            .build()
+  @Test
+  fun testSerializeRanges() {
+    val fury: Fury =
+      Fury.builder()
+        .withLanguage(Language.JAVA)
+        .requireClassRegistration(true)
+        .withRefTracking(true)
+        .build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value1 = 1..4
-        Assert.assertEquals(value1, fury.deserialize(fury.serialize(value1)))
+    KotlinSerializers.registerSerializers(fury)
+    val value1 = 1..4
+    Assert.assertEquals(value1, fury.deserialize(fury.serialize(value1)))
 
-        val value2 = 4 downTo 1
-        Assert.assertEquals(value2, fury.deserialize(fury.serialize(value2)))
+    val value2 = 4 downTo 1
+    Assert.assertEquals(value2, fury.deserialize(fury.serialize(value2)))
 
+    val value3 = 0 ..< 8 step 2
+    Assert.assertEquals(value3, fury.deserialize(fury.serialize(value3)))
 
-        val value3 = 0..<8 step 2
-        Assert.assertEquals(value3, fury.deserialize(fury.serialize(value3)))
+    val value4 = 'a'..'d'
+    Assert.assertEquals(value4, fury.deserialize(fury.serialize(value4)))
 
-        val value4 = 'a' .. 'd'
-        Assert.assertEquals(value4, fury.deserialize(fury.serialize(value4)))
+    val value5 = 'c' downTo 'a'
+    Assert.assertEquals(value5, fury.deserialize(fury.serialize(value5)))
 
+    val value6 = 0L..10L
+    Assert.assertEquals(value6, fury.deserialize(fury.serialize(value6)))
 
-        val value5 = 'c' downTo 'a'
-        Assert.assertEquals(value5, fury.deserialize(fury.serialize(value5)))
+    val value7 = 4L downTo 0L
+    Assert.assertEquals(value7, fury.deserialize(fury.serialize(value7)))
 
-        val value6 = 0L .. 10L
-        Assert.assertEquals(value6, fury.deserialize(fury.serialize(value6)))
+    val value8 = 0u..4u
+    Assert.assertEquals(value8, fury.deserialize(fury.serialize(value8)))
 
-        val value7 = 4L downTo 0L
-        Assert.assertEquals(value7, fury.deserialize(fury.serialize(value7)))
+    val value9 = 4u downTo 0u
+    Assert.assertEquals(value9, fury.deserialize(fury.serialize(value9)))
 
-        val value8 = 0u .. 4u
-        Assert.assertEquals(value8, fury.deserialize(fury.serialize(value8)))
+    val value10 = 0uL..4uL
+    Assert.assertEquals(value10, fury.deserialize(fury.serialize(value10)))
 
-        val value9 = 4u downTo  0u
-        Assert.assertEquals(value9, fury.deserialize(fury.serialize(value9)))
+    val value11 = 4uL downTo 0uL
+    Assert.assertEquals(value11, fury.deserialize(fury.serialize(value11)))
+  }
 
-        val value10 = 0uL .. 4uL
-        Assert.assertEquals(value10, fury.deserialize(fury.serialize(value10)))
+  @Test
+  fun testSerializeRandom() {
+    val fury: Fury =
+      Fury.builder()
+        .withLanguage(Language.JAVA)
+        .requireClassRegistration(true)
+        .withRefTracking(true)
+        .build()
 
-        val value11 = 4uL downTo  0uL
-        Assert.assertEquals(value11, fury.deserialize(fury.serialize(value11)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value1 = Random(123)
+    val roundtrip1 = fury.deserialize(fury.serialize(value1)) as Random
 
-    @Test
-    fun testSerializeRandom() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .withRefTracking(true)
-            .build()
+    Assert.assertEquals(roundtrip1.nextInt(), value1.nextInt())
 
-        KotlinSerializers.registerSerializers(fury)
-        val value1 = Random(123)
-        val roundtrip1 = fury.deserialize(fury.serialize(value1)) as Random
+    // The default random object will be roundtripped to the platform default random singleton
+    // object.
+    val value2 = Random.Default
+    val roundtrip2 = fury.deserialize(fury.serialize(value2)) as Random
 
-        Assert.assertEquals(roundtrip1.nextInt(), value1.nextInt())
+    Assert.assertEquals(roundtrip2, value2)
+  }
 
-        // The default random object will be roundtripped to the platform default random singleton object.
-        val value2 = Random.Default
-        val roundtrip2 = fury.deserialize(fury.serialize(value2)) as Random
+  @Test
+  fun testSerializeDuration() {
+    val fury: Fury =
+      Fury.builder()
+        .withLanguage(Language.JAVA)
+        .requireClassRegistration(true)
+        .withRefTracking(true)
+        .build()
 
-        Assert.assertEquals(roundtrip2, value2)
-    }
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testSerializeDuration() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .withRefTracking(true)
-            .build()
+    val value1 = Duration.ZERO
+    Assert.assertEquals(value1, fury.deserialize(fury.serialize(value1)))
 
-        KotlinSerializers.registerSerializers(fury)
+    val value2 = Duration.INFINITE
+    Assert.assertEquals(value2, fury.deserialize(fury.serialize(value2)))
 
-        val value1 = Duration.ZERO
-        Assert.assertEquals(value1, fury.deserialize(fury.serialize(value1)))
+    val value3 = -Duration.INFINITE
+    Assert.assertEquals(value3, fury.deserialize(fury.serialize(value3)))
 
-        val value2 = Duration.INFINITE
-        Assert.assertEquals(value2, fury.deserialize(fury.serialize(value2)))
+    val value4 = 1.nanoseconds
+    Assert.assertEquals(value4, fury.deserialize(fury.serialize(value4)))
 
-        val value3 = -Duration.INFINITE
-        Assert.assertEquals(value3, fury.deserialize(fury.serialize(value3)))
+    val value5 = 1.microseconds
+    Assert.assertEquals(value5, fury.deserialize(fury.serialize(value5)))
 
-        val value4 = 1.nanoseconds
-        Assert.assertEquals(value4, fury.deserialize(fury.serialize(value4)))
+    val value6 = 1.milliseconds
+    Assert.assertEquals(value6, fury.deserialize(fury.serialize(value6)))
 
-        val value5 = 1.microseconds
-        Assert.assertEquals(value5, fury.deserialize(fury.serialize(value5)))
+    val value7 = 3.141.milliseconds
+    Assert.assertEquals(value7, fury.deserialize(fury.serialize(value7)))
 
-        val value6 = 1.milliseconds
-        Assert.assertEquals(value6, fury.deserialize(fury.serialize(value6)))
+    val value8 = 1.seconds
+    Assert.assertEquals(value8, fury.deserialize(fury.serialize(value8)))
 
-        val value7 = 3.141.milliseconds
-        Assert.assertEquals(value7, fury.deserialize(fury.serialize(value7)))
+    val value9 = 3.141.seconds
+    Assert.assertEquals(value9, fury.deserialize(fury.serialize(value9)))
 
-        val value8 = 1.seconds
-        Assert.assertEquals(value8, fury.deserialize(fury.serialize(value8)))
+    val value10 = 5.minutes
+    Assert.assertEquals(value10, fury.deserialize(fury.serialize(value10)))
 
-        val value9 = 3.141.seconds
-        Assert.assertEquals(value9, fury.deserialize(fury.serialize(value9)))
+    val value11 = 60.minutes
+    Assert.assertEquals(value11, fury.deserialize(fury.serialize(value11)))
 
-        val value10 = 5.minutes
-        Assert.assertEquals(value10, fury.deserialize(fury.serialize(value10)))
+    val value12 = 12.hours
+    Assert.assertEquals(value12, fury.deserialize(fury.serialize(value12)))
 
-        val value11 = 60.minutes
-        Assert.assertEquals(value11, fury.deserialize(fury.serialize(value11)))
+    val value13 = 13.days
+    Assert.assertEquals(value13, fury.deserialize(fury.serialize(value13)))
 
-        val value12 = 12.hours
-        Assert.assertEquals(value12, fury.deserialize(fury.serialize(value12)))
+    val value14 = 356.days
+    Assert.assertEquals(value14, fury.deserialize(fury.serialize(value14)))
+  }
 
-        val value13 = 13.days
-        Assert.assertEquals(value13, fury.deserialize(fury.serialize(value13)))
+  @OptIn(ExperimentalUuidApi::class)
+  @Test
+  fun testSerializeUuid() {
+    val fury: Fury =
+      Fury.builder()
+        .withLanguage(Language.JAVA)
+        .requireClassRegistration(true)
+        .withRefTracking(true)
+        .build()
 
-        val value14 = 356.days
-        Assert.assertEquals(value14, fury.deserialize(fury.serialize(value14)))
-    }
+    KotlinSerializers.registerSerializers(fury)
 
-    @OptIn(ExperimentalUuidApi::class)
-    @Test
-    fun testSerializeUuid() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .withRefTracking(true)
-            .build()
+    val value = Uuid.fromLongs(1234L, 56789L)
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeRegex() {
+    val fury: Fury =
+      Fury.builder()
+        .withLanguage(Language.JAVA)
+        .requireClassRegistration(true)
+        .withRefTracking(true)
+        .build()
 
-        val value = Uuid.fromLongs(1234L, 56789L)
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
 
-    @Test
-    fun testSerializeRegex() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .withRefTracking(true)
-            .build()
-
-        KotlinSerializers.registerSerializers(fury)
-
-        val value = Regex("12345")
-        Assert.assertEquals(value.pattern, fury.deserialize(fury.serialize(value.pattern)))
-        Assert.assertEquals(value.options, fury.deserialize(fury.serialize(value.options)))
-    }
+    val value = Regex("12345")
+    Assert.assertEquals(value.pattern, fury.deserialize(fury.serialize(value.pattern)))
+    Assert.assertEquals(value.options, fury.deserialize(fury.serialize(value.options)))
+  }
 }

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializerTest.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/CollectionSerializerTest.kt
@@ -25,183 +25,153 @@ import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
 class CollectionSerializerTest {
-    @Test
-    fun testSerializeArrayDeque() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeArrayDeque() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val arrayDeque = ArrayDeque(listOf(1, 2, 3, 4, 5))
-        assertEquals(arrayDeque, fury.deserialize(fury.serialize(arrayDeque)))
-    }
+    val arrayDeque = ArrayDeque(listOf(1, 2, 3, 4, 5))
+    assertEquals(arrayDeque, fury.deserialize(fury.serialize(arrayDeque)))
+  }
 
-    @Test
-    fun testSerializeArrayList() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeArrayList() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val arrayList = arrayListOf(1, 2, 3, 4, 5)
-        assertEquals(arrayList, fury.deserialize(fury.serialize(arrayList)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val arrayList = arrayListOf(1, 2, 3, 4, 5)
+    assertEquals(arrayList, fury.deserialize(fury.serialize(arrayList)))
+  }
 
-    @Test
-    fun testSerializeEmptyList() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeEmptyList() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val emptyList = listOf<Int>()
-        assertEquals(emptyList, fury.deserialize(fury.serialize(emptyList)))
-    }
+    val emptyList = listOf<Int>()
+    assertEquals(emptyList, fury.deserialize(fury.serialize(emptyList)))
+  }
 
-    @Test
-    fun testSerializeList() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeList() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val list = listOf(1, 2, 3, 4, 5)
-        assertEquals(list, fury.deserialize(fury.serialize(list)))
-    }
+    val list = listOf(1, 2, 3, 4, 5)
+    assertEquals(list, fury.deserialize(fury.serialize(list)))
+  }
 
-    @Test
-    fun testSerializeMutableList() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeMutableList() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val mutableList = mutableListOf(1, 2, 3, 4, 5)
-        assertEquals(mutableList, fury.deserialize(fury.serialize(mutableList)))
-    }
+    val mutableList = mutableListOf(1, 2, 3, 4, 5)
+    assertEquals(mutableList, fury.deserialize(fury.serialize(mutableList)))
+  }
 
-    @Test
-    fun testSerializeEmptySet() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeEmptySet() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val emptySet = setOf<Int>()
-        assertEquals(emptySet, fury.deserialize(fury.serialize(emptySet)))
-    }
+    val emptySet = setOf<Int>()
+    assertEquals(emptySet, fury.deserialize(fury.serialize(emptySet)))
+  }
 
-    @Test
-    fun testSerializeSet() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeSet() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val set = setOf(1, 2, 3, 4, 5)
-        assertEquals(set, fury.deserialize(fury.serialize(set)))
-    }
+    val set = setOf(1, 2, 3, 4, 5)
+    assertEquals(set, fury.deserialize(fury.serialize(set)))
+  }
 
-    @Test
-    fun testSerializeMutableSet() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeMutableSet() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val mutableSet = mutableSetOf(1, 2, 3, 4, 5)
-        assertEquals(mutableSet, fury.deserialize(fury.serialize(mutableSet)))
-    }
+    val mutableSet = mutableSetOf(1, 2, 3, 4, 5)
+    assertEquals(mutableSet, fury.deserialize(fury.serialize(mutableSet)))
+  }
 
-    @Test
-    fun testSerializeHashSet() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeHashSet() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val set = hashSetOf(1, 2, 3, 4, 5)
-        assertEquals(set, fury.deserialize(fury.serialize(set)))
-    }
+    val set = hashSetOf(1, 2, 3, 4, 5)
+    assertEquals(set, fury.deserialize(fury.serialize(set)))
+  }
 
-    @Test
-    fun testSerializeLinkedSet() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeLinkedSet() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val set = linkedSetOf(1, 2, 3, 4, 5)
-        assertEquals(set, fury.deserialize(fury.serialize(set)))
-    }
+    val set = linkedSetOf(1, 2, 3, 4, 5)
+    assertEquals(set, fury.deserialize(fury.serialize(set)))
+  }
 
-    @Test
-    fun testSerializeEmptyMap() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeEmptyMap() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val emptyMap: Map<Int, String> = mapOf()
-        assertEquals(emptyMap, fury.deserialize(fury.serialize(emptyMap)))
-    }
+    val emptyMap: Map<Int, String> = mapOf()
+    assertEquals(emptyMap, fury.deserialize(fury.serialize(emptyMap)))
+  }
 
-    @Test
-    fun testSerializeMap() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeMap() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val map = mapOf(1 to "one", 2 to "two", 3 to "three")
-        assertEquals(map, fury.deserialize(fury.serialize(map)))
-    }
+    val map = mapOf(1 to "one", 2 to "two", 3 to "three")
+    assertEquals(map, fury.deserialize(fury.serialize(map)))
+  }
 
-    @Test
-    fun testSerializeMutableMap() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeMutableMap() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val mutableMap = mapOf(1 to "one", 2 to "two", 3 to "three")
-        assertEquals(mutableMap, fury.deserialize(fury.serialize(mutableMap)))
-    }
+    val mutableMap = mapOf(1 to "one", 2 to "two", 3 to "three")
+    assertEquals(mutableMap, fury.deserialize(fury.serialize(mutableMap)))
+  }
 
-    @Test
-    fun testSerializeHashMap() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeHashMap() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val map = hashMapOf(1 to "one", 2 to "two", 3 to "three")
-        assertEquals(map, fury.deserialize(fury.serialize(map)))
-    }
+    val map = hashMapOf(1 to "one", 2 to "two", 3 to "three")
+    assertEquals(map, fury.deserialize(fury.serialize(map)))
+  }
 
-    @Test
-    fun testSerializeLinkedMap() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
-        KotlinSerializers.registerSerializers(fury)
+  @Test
+  fun testSerializeLinkedMap() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+    KotlinSerializers.registerSerializers(fury)
 
-        val map = linkedMapOf(1 to "one", 2 to "two", 3 to "three")
-        assertEquals(map, fury.deserialize(fury.serialize(map)))
-    }
+    val map = linkedMapOf(1 to "one", 2 to "two", 3 to "three")
+    assertEquals(map, fury.deserialize(fury.serialize(map)))
+  }
 }

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/NullablePrimitiveSerializerTests.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/NullablePrimitiveSerializerTests.kt
@@ -27,148 +27,127 @@ import org.testng.annotations.Test
 /**
  * Nullable primitive serializer tests.
  *
- * Nullable primitives get translated into Boxed types in java.
- * See: https://kotlinlang.org/docs/numbers.html#numbers-representation-on-the-jvm
- *
+ * Nullable primitives get translated into Boxed types in java. See:
+ * https://kotlinlang.org/docs/numbers.html#numbers-representation-on-the-jvm
  */
 class NullablePrimitiveSerializerTests {
-    @Test
-    fun testSerializeBoxedByteValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeBoxedByteValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Byte? = 42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeBoxedIntValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Byte? = 42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Int? = 42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeBoxedShortValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeBoxedIntValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Short? = 42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Int? = 42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeBoxedLongValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeBoxedShortValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Long? = 42L
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Short? = 42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeBoxedFloatValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeBoxedLongValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Float? = .42f
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Long? = 42L
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeBoxedDoubleValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeBoxedFloatValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: Double? = .42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Float? = .42f
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeBoxedBooleanValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeBoxedDoubleValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: Boolean? = true
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeBoxedCharValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Double? = .42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: Char? = 'a'
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+  @Test
+  fun testSerializeBoxedBooleanValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-    @Test
-    fun testSerializeBoxedUByteValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Boolean? = true
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: UByte? = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+  @Test
+  fun testSerializeBoxedCharValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-    @Test
-    fun testSerializeBoxedUShortValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Char? = 'a'
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: UShort? = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+  @Test
+  fun testSerializeBoxedUByteValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-    @Test
-    fun testSerializeBoxedUIntValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: UByte? = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: UInt? = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeBoxedULongValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeBoxedUShortValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: ULong? = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: UShort? = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
+
+  @Test
+  fun testSerializeBoxedUIntValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+
+    KotlinSerializers.registerSerializers(fury)
+    val value: UInt? = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
+
+  @Test
+  fun testSerializeBoxedULongValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+
+    KotlinSerializers.registerSerializers(fury)
+    val value: ULong? = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 }

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/PrimitiveSerializerTest.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/PrimitiveSerializerTest.kt
@@ -25,143 +25,123 @@ import org.testng.Assert
 import org.testng.annotations.Test
 
 class PrimitiveSerializerTest {
-    @Test
-    fun testSerializeByteValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeByteValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Byte = 42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeIntValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Byte = 42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Int = 42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeShortValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeIntValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Short = 42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Int = 42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeLongValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeShortValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Long = 42L
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Short = 42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeFloatValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeLongValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:Float = .42f
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Long = 42L
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeDoubleValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeFloatValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: Double = .42
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: Float = .42f
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeBooleanValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeDoubleValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: Boolean = true
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeCharValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Double = .42
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: Char = 'a'
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+  @Test
+  fun testSerializeBooleanValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-    @Test
-    fun testSerializeUByteValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Boolean = true
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: UByte = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+  @Test
+  fun testSerializeCharValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-    @Test
-    fun testSerializeUShortValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: Char = 'a'
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: UShort = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+  @Test
+  fun testSerializeUByteValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-    @Test
-    fun testSerializeUIntValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+    KotlinSerializers.registerSerializers(fury)
+    val value: UByte = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: UInt = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
-    @Test
-    fun testSerializeULongValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeUShortValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value: ULong = 42u
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: UShort = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
+
+  @Test
+  fun testSerializeUIntValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+
+    KotlinSerializers.registerSerializers(fury)
+    val value: UInt = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
+
+  @Test
+  fun testSerializeULongValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
+
+    KotlinSerializers.registerSerializers(fury)
+    val value: ULong = 42u
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 }

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/StringsSerializerTest.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/StringsSerializerTest.kt
@@ -25,27 +25,23 @@ import org.testng.Assert
 import org.testng.annotations.Test
 
 class StringsSerializerTest {
-    @Test
-    fun testSerializeStringValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeStringValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:String = "Hello World!"
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: String = "Hello World!"
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 
-    @Test
-    fun testSerializeNullableStringValue() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testSerializeNullableStringValue() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
-        val value:String? = null
-        Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
-    }
+    KotlinSerializers.registerSerializers(fury)
+    val value: String? = null
+    Assert.assertEquals(value, fury.deserialize(fury.serialize(value)))
+  }
 }

--- a/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/UnsignedBoundarySerializerTests.kt
+++ b/kotlin/src/test/kotlin/org/apache/fury/serializer/kotlin/UnsignedBoundarySerializerTests.kt
@@ -26,123 +26,107 @@ import org.testng.annotations.Test
 
 @ExperimentalUnsignedTypes
 class UnsignedBoundarySerializerTests {
-    @Test
-    fun testUByteBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testUByteBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val boundaryMin = UByte.MIN_VALUE
-        val boundaryMax = UByte.MAX_VALUE
+    val boundaryMin = UByte.MIN_VALUE
+    val boundaryMax = UByte.MAX_VALUE
 
-        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
-        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
-    }
+    Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+    Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+  }
 
-    @Test
-    fun testUShortBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testUShortBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val boundaryMin = UShort.MIN_VALUE
-        val boundaryMax = UShort.MAX_VALUE
+    val boundaryMin = UShort.MIN_VALUE
+    val boundaryMax = UShort.MAX_VALUE
 
-        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
-        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
-    }
+    Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+    Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+  }
 
-    @Test
-    fun testUIntBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testUIntBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val boundaryMin = UInt.MIN_VALUE
-        val boundaryMax = UInt.MAX_VALUE
+    val boundaryMin = UInt.MIN_VALUE
+    val boundaryMax = UInt.MAX_VALUE
 
-        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
-        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
-    }
+    Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+    Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+  }
 
-    @Test
-    fun testULongBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testULongBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val boundaryMin = ULong.MIN_VALUE
-        val boundaryMax = ULong.MAX_VALUE
+    val boundaryMin = ULong.MIN_VALUE
+    val boundaryMax = ULong.MAX_VALUE
 
-        Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
-        Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
-    }
+    Assert.assertEquals(boundaryMin, fury.deserialize(fury.serialize(boundaryMin)))
+    Assert.assertEquals(boundaryMax, fury.deserialize(fury.serialize(boundaryMax)))
+  }
 
-    @Test
-    fun testUByteArrayBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testUByteArrayBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val array = ubyteArrayOf(UByte.MIN_VALUE, UByte.MAX_VALUE)
+    val array = ubyteArrayOf(UByte.MIN_VALUE, UByte.MAX_VALUE)
 
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UByteArray))
-    }
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UByteArray))
+  }
 
-    @Test
-    fun testUShortArrayBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testUShortArrayBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val array = ushortArrayOf(UShort.MIN_VALUE, UShort.MAX_VALUE)
+    val array = ushortArrayOf(UShort.MIN_VALUE, UShort.MAX_VALUE)
 
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UShortArray))
-    }
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UShortArray))
+  }
 
-    @Test
-    fun testUIntArrayBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testUIntArrayBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val array = uintArrayOf(UInt.MIN_VALUE, UInt.MAX_VALUE)
+    val array = uintArrayOf(UInt.MIN_VALUE, UInt.MAX_VALUE)
 
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UIntArray))
-    }
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as UIntArray))
+  }
 
-    @Test
-    fun testULongArrayBoundarySerialization() {
-        val fury: Fury = Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(true)
-            .build()
+  @Test
+  fun testULongArrayBoundarySerialization() {
+    val fury: Fury =
+      Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build()
 
-        KotlinSerializers.registerSerializers(fury)
+    KotlinSerializers.registerSerializers(fury)
 
-        val array = ulongArrayOf(ULong.MIN_VALUE, ULong.MAX_VALUE)
+    val array = ulongArrayOf(ULong.MIN_VALUE, ULong.MAX_VALUE)
 
-        assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as ULongArray))
-    }
+    assert(array.contentEquals(fury.deserialize(fury.serialize(array)) as ULongArray))
+  }
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR modifies the build to:
1) add ktfmt - Since the fury java uses GOOGLE style, the fury kotlin will also use GOOGLE style. The version of ktfmt used is the highest compatible with the spotless maven plugin.
2) explicit api mode
3) parameterized kotlin version in pom.xml so it is easy to change in future
4) Update README.md with build, format and testing instructions.

## Related issues

#1896 

## Does this PR introduce any user-facing change?
None.

## Benchmark
N/A
