### PR TITLE
fix(java): Fix incorrect results of utf16 to utf8 conversion for latin1 but not ascii characters

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/StringUtils.java
@@ -28,6 +28,8 @@ public class StringUtils {
   // A long mask used to clear all-higher bits of char in a super-word way.
   public static final long MULTI_CHARS_NON_LATIN_MASK;
 
+  public static final long MULTI_CHARS_NON_ASCII_MASK;
+
   private static final char[] BASE16_CHARS2 = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
   };
@@ -37,10 +39,12 @@ public class StringUtils {
       // latin chars will be 0xXX,0x00;0xXX,0x00 in byte order;
       // Using 0x00,0xff(0xff00) to clear latin bits.
       MULTI_CHARS_NON_LATIN_MASK = 0xff00ff00ff00ff00L;
+      MULTI_CHARS_NON_ASCII_MASK = 0xff80ff80ff80ff80L;
     } else {
       // latin chars will be 0x00,0xXX;0x00,0xXX in byte order;
       // Using 0x00,0xff(0x00ff) to clear latin bits.
       MULTI_CHARS_NON_LATIN_MASK = 0x00ff00ff00ff00ffL;
+      MULTI_CHARS_NON_ASCII_MASK = 0x80ff80ff80ff80ffL;
     }
   }
 

--- a/java/fury-core/src/test/java/org/apache/fury/util/StringEncodingUtilsTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/util/StringEncodingUtilsTest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 public class StringEncodingUtilsTest extends FuryTestBase {
   @Test
   public void testUTF8ToUTF16() {
-    String input = "你好, Fury";
+    String input = "jbmbmner8 jhk hj \n \t üäßß@µ你好";
     byte[] utf8 = input.getBytes(StandardCharsets.UTF_8);
     char[] utf16Chars = new char[utf8.length * 2];
     int readLen = StringEncodingUtils.convertUTF8ToUTF16(utf8, 0, utf8.length, utf16Chars);
@@ -43,7 +43,7 @@ public class StringEncodingUtilsTest extends FuryTestBase {
 
   @Test
   public void testUTF16ToUTF8() {
-    String input = "你好, Fury";
+    String input = "jbmbmner8 jhk hj \n \t üäßß@µ你好";
     char[] utf16 = new char[input.length()];
     byte[] utf8 = new byte[input.length() * 3];
     input.getChars(0, input.length(), utf16, 0);


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->

Fix incorrect results of utf16 to utf8 conversion for latin1 but not ascii characters

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
