### PR TITLE
feat(java): Improve error message on architecture not using little-endian format

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -761,8 +761,9 @@ public final class Fury implements BaseFury {
       if ((bitmap & isNilFlag) == isNilFlag) {
         return null;
       }
-      boolean isLittleEndian = (bitmap & isLittleEndianFlag) == isLittleEndianFlag;
-      Preconditions.checkArgument(Fury.isLittleEndian, isLittleEndian);
+      Preconditions.checkArgument(
+          Fury.isLittleEndian,
+          "Non-Little-Endian format detected. Only Little-Endian is supported.");
       boolean isTargetXLang = (bitmap & isCrossLanguageFlag) == isCrossLanguageFlag;
       if (isTargetXLang) {
         peerLanguage = Language.values()[buffer.readByte()];


### PR DESCRIPTION


<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

previously there was this kind of error stacktrace:
```
Caused by: java.lang.IllegalArgumentException: false
	at org.apache.fury.util.Preconditions.checkArgument(Preconditions.java:52)
	at org.apache.fury.Fury.deserialize(Fury.java:765)
	at org.apache.fury.Fury.deserialize(Fury.java:815)
	at org.apache.fury.Fury.deserialize(Fury.java:808)
	at org.apache.camel.component.fury.FuryDataFormat.unmarshal(FuryDataFormat.java:79)
```

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
