### PR TITLE
chore(ci): Migrate the ci from macOS 12 to macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
     name: Rust CI
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14] # macos-12: x86, macos-14: arm64
+        os: [ubuntu-latest, macos-13, macos-14] # macos-13: x86, macos-14: arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
@@ -201,7 +201,7 @@ jobs:
     name: C++ CI
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14, windows-2022] # macos-12: x86, macos-14: arm64
+        os: [ubuntu-latest, macos-13, macos-14, windows-2022] # macos-13: x86, macos-14: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do?

macos-12 is being deprecated https://github.com/actions/runner-images/issues/10721
Replacing it with macos-13 which also runs on x86-64

## Related issues

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark