### PR TITLE
【Java】add deserial object with feature deserializeNonexistentClassNotWriteFullClassInfo feature

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/config/Config.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/Config.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.fury.Fury;
 import org.apache.fury.meta.MetaCompressor;
 import org.apache.fury.serializer.Serializer;
@@ -57,6 +58,7 @@ public class Config implements Serializable {
   private final MetaCompressor metaCompressor;
   private final boolean asyncCompilationEnabled;
   private final boolean deserializeNonexistentClass;
+  private final boolean deserializeNonexistentClassNotWriteFullClassInfo;
   private final boolean scalaOptimizationEnabled;
   private transient int configHash;
   private final boolean deserializeNonexistentEnumValueAsNull;
@@ -91,6 +93,7 @@ public class Config implements Serializable {
       // unexisted class by type info in data.
       Preconditions.checkArgument(metaShareEnabled || compatibleMode == CompatibleMode.COMPATIBLE);
     }
+    deserializeNonexistentClassNotWriteFullClassInfo = builder.deserializeNonexistentClassNotWriteFullClassInfo;
     asyncCompilationEnabled = builder.asyncCompilationEnabled;
     scalaOptimizationEnabled = builder.scalaOptimizationEnabled;
     deserializeNonexistentEnumValueAsNull = builder.deserializeNonexistentEnumValueAsNull;
@@ -240,6 +243,13 @@ public class Config implements Serializable {
   }
 
   /**
+   * Whether deserialize/skip data of un-existed class with full Class info. if enable then not write full class info
+   */
+  public boolean deserializeNonexistentClassNotWriteFullClassInfo() {
+    return deserializeNonexistentClassNotWriteFullClassInfo;
+  }
+
+  /**
    * Whether JIT is enabled.
    *
    * @see #isAsyncCompilationEnabled
@@ -291,6 +301,7 @@ public class Config implements Serializable {
         && Objects.equals(metaCompressor, config.metaCompressor)
         && asyncCompilationEnabled == config.asyncCompilationEnabled
         && deserializeNonexistentClass == config.deserializeNonexistentClass
+        && deserializeNonexistentClassNotWriteFullClassInfo == config.deserializeNonexistentClassNotWriteFullClassInfo
         && scalaOptimizationEnabled == config.scalaOptimizationEnabled
         && language == config.language
         && compatibleMode == config.compatibleMode
@@ -325,6 +336,7 @@ public class Config implements Serializable {
         metaCompressor,
         asyncCompilationEnabled,
         deserializeNonexistentClass,
+        deserializeNonexistentClassNotWriteFullClassInfo,
         scalaOptimizationEnabled);
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
@@ -77,6 +77,12 @@ public final class FuryBuilder {
   Boolean scopedMetaShareEnabled;
   boolean codeGenEnabled = true;
   Boolean deserializeNonexistentClass;
+    /**
+     * Whether deserialize nonexistent class not write full class info
+     * default write full class info
+     * if enable then not write full class info
+      */
+  boolean deserializeNonexistentClassNotWriteFullClassInfo = false;
   boolean asyncCompilationEnabled = false;
   boolean registerGuavaTypes = true;
   boolean scalaOptimizationEnabled = false;
@@ -294,6 +300,16 @@ public final class FuryBuilder {
    */
   public FuryBuilder withDeserializeNonexistentClass(boolean deserializeNonexistentClass) {
     this.deserializeNonexistentClass = deserializeNonexistentClass;
+    return this;
+  }
+
+  /**
+   * Whether deserialize/skip data of un-existed class. if write class full info
+   *
+   * @see Config#deserializeNonexistentClassNotWriteFullClassInfo()
+   */
+  public FuryBuilder withDeserializeNonexistentClassNotWriteFullClassInfo(boolean deserializeNonexistentClassNotWriteFullClassInfo) {
+    this.deserializeNonexistentClassNotWriteFullClassInfo = deserializeNonexistentClassNotWriteFullClassInfo;
     return this;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/NonexistentClassSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/NonexistentClassSerializers.java
@@ -28,6 +28,7 @@ import org.apache.fury.collection.LongMap;
 import org.apache.fury.collection.MapEntry;
 import org.apache.fury.collection.Tuple2;
 import org.apache.fury.collection.Tuple3;
+import org.apache.fury.config.Config;
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.meta.ClassDef;
 import org.apache.fury.resolver.ClassInfo;
@@ -193,6 +194,7 @@ public final class NonexistentClassSerializers {
       ClassFieldsInfo fieldsInfo = getClassFieldsInfo(classDef);
       ObjectSerializer.FinalTypeField[] finalFields = fieldsInfo.finalFields;
       boolean[] isFinal = fieldsInfo.isFinal;
+      Config config = fury.getConfig();
       for (int i = 0; i < finalFields.length; i++) {
         ObjectSerializer.FinalTypeField fieldInfo = finalFields[i];
         Object fieldValue;
@@ -208,21 +210,33 @@ public final class NonexistentClassSerializers {
                     fury, refResolver, classResolver, fieldInfo, isFinal[i], buffer);
           }
         }
-        entries.add(new MapEntry(fieldInfo.qualifiedFieldName, fieldValue));
+        entries.add(new MapEntry(getFileName(fieldInfo.qualifiedFieldName, config), fieldValue));
       }
       for (ObjectSerializer.GenericTypeField fieldInfo : fieldsInfo.otherFields) {
         Object fieldValue = ObjectSerializer.readOtherFieldValue(fury, fieldInfo, buffer);
-        entries.add(new MapEntry(fieldInfo.qualifiedFieldName, fieldValue));
+        entries.add(new MapEntry(getFileName(fieldInfo.qualifiedFieldName, config), fieldValue));
       }
       Generics generics = fury.getGenerics();
       for (ObjectSerializer.GenericTypeField fieldInfo : fieldsInfo.containerFields) {
         Object fieldValue =
             ObjectSerializer.readContainerFieldValue(fury, generics, fieldInfo, buffer);
-        entries.add(new MapEntry(fieldInfo.qualifiedFieldName, fieldValue));
+        entries.add(new MapEntry(getFileName(fieldInfo.qualifiedFieldName, config), fieldValue));
       }
       obj.setEntries(entries);
       return obj;
     }
+  }
+
+  public static String getFileName(String qualifiedFieldName, Config config) {
+      if (config.deserializeNonexistentClassNotWriteFullClassInfo()) {
+          int index = qualifiedFieldName.lastIndexOf(".");
+          if (index < 0) {
+              return qualifiedFieldName;
+          }
+          return qualifiedFieldName.substring(index + 1);
+      } else {
+          return qualifiedFieldName;
+      }
   }
 
   public static final class NonexistentEnumClassSerializer extends Serializer {

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/NonexistentClassSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/NonexistentClassSerializersTest.java
@@ -108,6 +108,44 @@ public class NonexistentClassSerializersTest extends FuryTestBase {
     }
   }
 
+    @Test(dataProvider = "config")
+    public void testSkipNonexistentWithNoneClassInfo(
+        boolean referenceTracking,
+        boolean scopedMetaShare,
+        boolean enableCodegen1,
+        boolean enableCodegen2) {
+        Fury fury =
+            furyBuilder(scopedMetaShare)
+                .withRefTracking(referenceTracking)
+                .withCodegen(enableCodegen1)
+                .withCompatibleMode(CompatibleMode.COMPATIBLE)
+                .withDeserializeNonexistentClassNotWriteFullClassInfo(true)
+                .build();
+        ClassLoader classLoader = getClass().getClassLoader();
+        for (Class<?> structClass :
+            new Class<?>[] {
+                Struct.createNumberStructClass("TestSkipNonexistentClass1", 2),
+                Struct.createStructClass("TestSkipNonexistentClass1", 2)
+            }) {
+            Object pojo = Struct.createPOJO(structClass);
+            byte[] bytes = fury.serialize(pojo);
+            Fury fury2 =
+                furyBuilder(scopedMetaShare)
+                    .withRefTracking(referenceTracking)
+                    .withCodegen(enableCodegen2)
+                    .withClassLoader(classLoader)
+                    .withDeserializeNonexistentClassNotWriteFullClassInfo(true)
+                    .build();
+            Object o = fury2.deserialize(bytes);
+            if (o instanceof NonexistentClass.NonexistentMetaShared) {
+                System.out.println(o);
+                NonexistentClass.NonexistentMetaShared s = (NonexistentClass.NonexistentMetaShared)o;
+                Assert.assertNotNull(s.get("f0"));
+            }
+            assertTrue(o instanceof NonexistentClass, "Unexpect type " + o.getClass());
+        }
+    }
+
   @Test(dataProvider = "scopedMetaShare")
   public void testNonexistentEnum(boolean scopedMetaShare) {
     Fury fury = furyBuilder(scopedMetaShare).withDeserializeNonexistentClass(true).build();


### PR DESCRIPTION
…ullClassInfo

<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

we has some scene , after the class with the upstream system serialized, the downstream system can not deserialize without the class object, but current .withDeserializeNonexistentClass write the full class info. we want fury support deserialize object when none local class can deserializeNonexistentClassNotWriteFullClassInfo feature



## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
