### PR TITLE
perf(python): Improve tuple and list serializer performance

### DIFF
--- a/integration_tests/cpython_benchmark/fury_benchmark.py
+++ b/integration_tests/cpython_benchmark/fury_benchmark.py
@@ -90,9 +90,11 @@ TUPLE = (
     ],
     60,
 )
+LARGE_TUPLE = tuple(range(2**20 + 1))
 
 
 LIST = [[list(range(10)), list(range(10))] for _ in range(10)]
+LARGE_LIST = [i for i in range(2**20 + 1)]
 
 
 def mutate_dict(orig_dict, random_source):
@@ -169,7 +171,7 @@ def benchmark_args():
 def micro_benchmark():
     args = benchmark_args()
     runner = pyperf.Runner()
-    if args.disable_cython:
+    if args and args.disable_cython:
         os.environ["ENABLE_FURY_CYTHON_SERIALIZATION"] = "0"
         sys.argv += ["--inherit-environ", "ENABLE_FURY_CYTHON_SERIALIZATION"]
     runner.parse_args()
@@ -179,7 +181,13 @@ def micro_benchmark():
         "fury_dict_group", fury_object, language, not args.no_ref, DICT_GROUP
     )
     runner.bench_func("fury_tuple", fury_object, language, not args.no_ref, TUPLE)
+    runner.bench_func(
+        "fury_large_tuple", fury_object, language, not args.no_ref, LARGE_TUPLE
+    )
     runner.bench_func("fury_list", fury_object, language, not args.no_ref, LIST)
+    runner.bench_func(
+        "fury_large_list", fury_object, language, not args.no_ref, LARGE_LIST
+    )
     runner.bench_func(
         "fury_complex", fury_object, language, not args.no_ref, COMPLEX_OBJECT
     )


### PR DESCRIPTION
## What does this PR do?

Pre-allocate memory for sequence containers based on the data size to avoid resizing and improve deserialization performance.

## Related issues

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
python format
```
python -m pyperf compare_to base.json opt.json
fury_large_tuple: Mean +- std dev: [base] 104 ms +- 2 ms -> [opt] 92.7 ms +- 5.5 ms: 1.13x faster
fury_large_list: Mean +- std dev: [base] 98.5 ms +- 3.7 ms -> [opt] 92.8 ms +- 5.3 ms: 1.06x faster

Benchmark hidden because not significant (2): fury_tuple, fury_list
```

xlang format
```
python -m pyperf compare_to base_xlang.json opt_xlang.json
fury_tuple: Mean +- std dev: [base_xlang] 262 us +- 6 us -> [opt_xlang] 259 us +- 5 us: 1.01x faster
fury_large_tuple: Mean +- std dev: [base_xlang] 104 ms +- 4 ms -> [opt_xlang] 90.0 ms +- 4.6 ms: 1.16x faster
fury_large_list: Mean +- std dev: [base_xlang] 97.6 ms +- 3.7 ms -> [opt_xlang] 90.0 ms +- 4.3 ms: 1.08x faster

Benchmark hidden because not significant (1): fury_list
```
