### PR TITLE
feat(python): Implement collection serialization protocol

### DIFF
--- a/python/pyfury/_serialization.pyx
+++ b/python/pyfury/_serialization.pyx
@@ -1722,43 +1722,43 @@ cdef class CollectionSerializer(Serializer):
                         classinfo.serializer.write(buffer, s)
 
     cdef inline _write_string(self, Buffer buffer, value):
+        buffer.write_int16(NOT_NULL_STRING_FLAG)
         for s in value:
-            buffer.write_int16(NOT_NULL_STRING_FLAG)
             buffer.write_string(s)
 
     cdef inline _read_string(self, Buffer buffer, int64_t len_, object collection_):
+        assert buffer.read_int16() == NOT_NULL_STRING_FLAG
         for i in range(len_):
-            assert buffer.read_int16() == NOT_NULL_STRING_FLAG
             self._add_element(collection_, i, buffer.read_string())
 
     cdef inline _write_int(self, Buffer buffer, value):
+        buffer.write_int16(NOT_NULL_PYINT_FLAG)
         for s in value:
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
             buffer.write_varint64(s)
 
     cdef inline _read_int(self, Buffer buffer, int64_t len_, object collection_):
+        assert buffer.read_int16() == NOT_NULL_PYINT_FLAG
         for i in range(len_):
-            assert buffer.read_int16() == NOT_NULL_PYINT_FLAG
             self._add_element(collection_, i, buffer.read_varint64())
 
     cdef inline _write_bool(self, Buffer buffer, value):
+        buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
         for s in value:
-            buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
             buffer.write_bool(s)
 
     cdef inline _read_bool(self, Buffer buffer, int64_t len_, object collection_):
+        assert buffer.read_int16() == NOT_NULL_PYBOOL_FLAG
         for i in range(len_):
-            assert buffer.read_int16() == NOT_NULL_PYBOOL_FLAG
             self._add_element(collection_, i, buffer.read_bool())
 
     cdef inline _write_float(self, Buffer buffer, value):
+        buffer.write_int16(NOT_NULL_PYFLOAT_FLAG)
         for s in value:
-            buffer.write_int16(NOT_NULL_PYFLOAT_FLAG)
             buffer.write_double(s)
 
     cdef inline _read_float(self, Buffer buffer, int64_t len_, object collection_):
+        assert buffer.read_int16() == NOT_NULL_PYFLOAT_FLAG
         for i in range(len_):
-            assert buffer.read_int16() == NOT_NULL_PYFLOAT_FLAG
             self._add_element(collection_, i, buffer.read_double())
 
     cpdef _write_same_type_no_ref(self, Buffer buffer, value, elem_type):


### PR DESCRIPTION
## What does this PR do?

Implement a new format for collection serialization in pyfury.

## Related issues

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

```
fury_tuple: Mean +- std dev: [base] 259 us +- 6 us -> [collection] 256 us +- 5 us: 1.01x faster
fury_large_tuple: Mean +- std dev: [base] 92.7 ms +- 5.5 ms -> [collection] 63.7 ms +- 4.8 ms: 1.46x faster
fury_list: Mean +- std dev: [base] 277 us +- 6 us -> [collection] 267 us +- 3 us: 1.04x faster
fury_large_list: Mean +- std dev: [base] 92.8 ms +- 5.3 ms -> [collection] 66.5 ms +- 3.0 ms: 1.40x faster

Geometric mean: 1.21x faster
```
