### PR TITLE
fix(java):ClassLoaderFuryPooled#setFactoryCallback cannot effect old Fury

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/pool/ClassLoaderFuryPooled.java
+++ b/java/fury-core/src/main/java/org/apache/fury/pool/ClassLoaderFuryPooled.java
@@ -123,6 +123,7 @@ public class ClassLoaderFuryPooled {
   }
 
   void setFactoryCallback(Consumer<Fury> factoryCallback) {
-    this.factoryCallback = factoryCallback;
+    this.factoryCallback = this.factoryCallback.andThen(factoryCallback);
+    allFury.keySet().forEach(factoryCallback);
   }
 }

--- a/java/fury-core/src/test/java/org/apache/fury/pool/ClassLoaderFuryPooledTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/pool/ClassLoaderFuryPooledTest.java
@@ -84,6 +84,23 @@ public class ClassLoaderFuryPooledTest {
   }
 
   @Test
+  public void testFuryAfterSetFactoryCallback() {
+    int minPoolSize = 4;
+    ClassLoaderFuryPooled pooled = getPooled(minPoolSize, 6);
+
+    try {
+      pooled.setFactoryCallback(
+          fury -> {
+            throw new RuntimeException();
+          });
+      pooled.getFury();
+      Assert.fail();
+    } catch (RuntimeException e) {
+      // Success
+    }
+  }
+
+  @Test
   public void testGetFuryAwait() throws InterruptedException {
     int minPoolSize = 3;
     ClassLoaderFuryPooled pooled = getPooled(minPoolSize, 3);


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

ClassLoaderFuryPooled#setFactoryCallback cannot effect old fury. 
so if `org.apache.fury.pool.FuryPooledObjectFactory#classLoaderFuryPooledCache` expired, new classLoaderFuryPooled can not effected by custom factoryCallback

<!-- Describe the purpose of this PR. -->

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
