### PR TITLE
fix(java): fix find constructor error in generated serializer class caused by duplicated class classloading for Fury

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecUtils.java
@@ -28,6 +28,7 @@ import org.apache.fury.reflect.TypeRef;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.resolver.FieldResolver;
 import org.apache.fury.serializer.Serializer;
+import org.apache.fury.util.ClassLoaderUtils;
 import org.apache.fury.util.Preconditions;
 
 /** Codec util to create and load jit serializer class. */
@@ -100,7 +101,7 @@ public class CodecUtils {
       if (codeGenerator == null) {
         codeGenerator =
             CodeGenerator.getSharedCodeGenerator(
-                beanClassClassLoader, fury.getClass().getClassLoader());
+                ClassLoaderUtils.FuryJarClassLoader.getInstance(), beanClassClassLoader);
         // Hold strong reference of {@link CodeGenerator}, so the referent of `DelayedRef`
         // won't be null.
         classResolver.setCodeGenerator(loaders, codeGenerator);

--- a/java/fury-core/src/main/java/org/apache/fury/util/ClassLoaderUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/ClassLoaderUtils.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import org.apache.fury.Fury;
 import org.apache.fury.logging.Logger;
 import org.apache.fury.logging.LoggerFactory;
 import org.apache.fury.util.unsafe.DefineClass;
@@ -165,6 +166,33 @@ public class ClassLoaderUtils {
         }
       }
       return super.getResource(name);
+    }
+  }
+
+  /** A classloader to load Fury jar classes only. */
+  public static class FuryJarClassLoader extends URLClassLoader {
+    static {
+      ClassLoader.registerAsParallelCapable();
+    }
+
+    private static final ParentClassLoader LOADER =
+        new ParentClassLoader(Fury.class.getClassLoader());
+    private static final FuryJarClassLoader FURY_JAR_LOADER = new FuryJarClassLoader();
+
+    private FuryJarClassLoader() {
+      super(new URL[0]);
+    }
+
+    @Override
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+      if (name.startsWith(Fury.class.getPackage().getName())) {
+        return LOADER.loadClass(name, resolve);
+      }
+      return null;
+    }
+
+    public static FuryJarClassLoader getInstance() {
+      return FURY_JAR_LOADER;
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/util/ClassLoaderUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/ClassLoaderUtils.java
@@ -185,7 +185,7 @@ public class ClassLoaderUtils {
 
     @Override
     public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-      if (name.startsWith(Fury.class.getPackage().getName())) {
+      if (name.startsWith(Fury.class.getPackage().getName()) && !name.contains("test")) {
         return LOADER.loadClass(name, resolve);
       }
       return null;

--- a/java/fury-core/src/test/java/org/apache/fury/codegen/CodeGeneratorTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/codegen/CodeGeneratorTest.java
@@ -38,6 +38,7 @@ import org.apache.fury.collection.MultiKeyWeakMap;
 import org.apache.fury.test.bean.Foo;
 import org.apache.fury.util.ClassLoaderUtils;
 import org.apache.fury.util.ClassLoaderUtils.ByteArrayClassLoader;
+import org.apache.fury.util.ClassLoaderUtils.FuryJarClassLoader;
 import org.apache.fury.util.DelayedRef;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -70,6 +71,13 @@ public class CodeGeneratorTest {
     assertNotNull(
         sharedCodeGenerator2
             .get(new Object[] {getClass().getClassLoader(), Fury.class.getClassLoader()})
+            .get());
+    CodeGenerator.getSharedCodeGenerator(
+        FuryJarClassLoader.getInstance(), getClass().getClassLoader());
+    System.gc();
+    assertNotNull(
+        sharedCodeGenerator2
+            .get(new Object[] {FuryJarClassLoader.getInstance(), getClass().getClassLoader()})
             .get());
   }
 


### PR DESCRIPTION

## What does this PR do?

fix duplicate classloading in parent classloader.

Some classloader such as flink classloader can load class from children classloader. If fury is located in children classloader, but we are serializing a class in such parent class, the  parent class will load Fury class again, which caused two Fury clases loaded.

## Related issues
Closes #1947 

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
