### PR TITLE
feat(java): make 4 bytes utf16 size header optional for utf8 encoding

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/config/Config.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/Config.java
@@ -46,6 +46,7 @@ public class Config implements Serializable {
   private final boolean checkJdkClassSerializable;
   private final Class<? extends Serializer> defaultJDKStreamSerializerType;
   private final boolean compressString;
+  private final boolean writeNumUtf16BytesForUtf8Encoding;
   private final boolean compressInt;
   private final boolean compressLong;
   private final LongEncoding longEncoding;
@@ -72,6 +73,7 @@ public class Config implements Serializable {
     timeRefIgnored = !trackingRef || builder.timeRefIgnored;
     copyRef = builder.copyRef;
     compressString = builder.compressString;
+    writeNumUtf16BytesForUtf8Encoding = builder.writeNumUtf16BytesForUtf8Encoding;
     compressInt = builder.compressInt;
     longEncoding = builder.longEncoding;
     compressLong = longEncoding != LongEncoding.LE_RAW_BYTES;
@@ -174,6 +176,10 @@ public class Config implements Serializable {
 
   public boolean compressString() {
     return compressString;
+  }
+
+  public boolean writeNumUtf16BytesForUtf8Encoding() {
+    return writeNumUtf16BytesForUtf8Encoding;
   }
 
   public boolean compressInt() {
@@ -287,6 +293,7 @@ public class Config implements Serializable {
         && checkClassVersion == config.checkClassVersion
         && checkJdkClassSerializable == config.checkJdkClassSerializable
         && compressString == config.compressString
+        && writeNumUtf16BytesForUtf8Encoding == config.writeNumUtf16BytesForUtf8Encoding
         && compressInt == config.compressInt
         && compressLong == config.compressLong
         && bufferSizeLimitBytes == config.bufferSizeLimitBytes
@@ -321,6 +328,7 @@ public class Config implements Serializable {
         checkJdkClassSerializable,
         defaultJDKStreamSerializerType,
         compressString,
+        writeNumUtf16BytesForUtf8Encoding,
         compressInt,
         compressLong,
         longEncoding,

--- a/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
@@ -69,6 +69,7 @@ public final class FuryBuilder {
   boolean compressInt = true;
   public LongEncoding longEncoding = LongEncoding.SLI;
   boolean compressString = false;
+  boolean writeNumUtf16BytesForUtf8Encoding = false;
   CompatibleMode compatibleMode = CompatibleMode.SCHEMA_CONSISTENT;
   boolean checkJdkClassSerializable = true;
   Class<? extends Serializer> defaultJDKStreamSerializerType = ObjectStreamSerializer.class;
@@ -182,6 +183,18 @@ public final class FuryBuilder {
   /** Whether compress string for small size. */
   public FuryBuilder withStringCompressed(boolean stringCompressed) {
     this.compressString = stringCompressed;
+    return this;
+  }
+
+  /**
+   * Whether write num_bytes of utf16 for utf8 encoding. With this option enabled,
+   * fury will write the num_bytes of utf16 before write utf8 encoded data, so that
+   * the deserialization can create the appropriate utf16 array for store the data, thus
+   * save one copy.
+   */
+  public FuryBuilder withWriteNumUtf16BytesForUtf8Encoding(
+    boolean writeNumUtf16BytesForUtf8Encoding) {
+    this.writeNumUtf16BytesForUtf8Encoding = writeNumUtf16BytesForUtf8Encoding;
     return this;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
@@ -69,7 +69,7 @@ public final class FuryBuilder {
   boolean compressInt = true;
   public LongEncoding longEncoding = LongEncoding.SLI;
   boolean compressString = false;
-  boolean writeNumUtf16BytesForUtf8Encoding = false;
+  Boolean writeNumUtf16BytesForUtf8Encoding;
   CompatibleMode compatibleMode = CompatibleMode.SCHEMA_CONSISTENT;
   boolean checkJdkClassSerializable = true;
   Class<? extends Serializer> defaultJDKStreamSerializerType = ObjectStreamSerializer.class;
@@ -187,13 +187,12 @@ public final class FuryBuilder {
   }
 
   /**
-   * Whether write num_bytes of utf16 for utf8 encoding. With this option enabled,
-   * fury will write the num_bytes of utf16 before write utf8 encoded data, so that
-   * the deserialization can create the appropriate utf16 array for store the data, thus
-   * save one copy.
+   * Whether write num_bytes of utf16 for utf8 encoding. With this option enabled, fury will write
+   * the num_bytes of utf16 before write utf8 encoded data, so that the deserialization can create
+   * the appropriate utf16 array for store the data, thus save one copy.
    */
   public FuryBuilder withWriteNumUtf16BytesForUtf8Encoding(
-    boolean writeNumUtf16BytesForUtf8Encoding) {
+      boolean writeNumUtf16BytesForUtf8Encoding) {
     this.writeNumUtf16BytesForUtf8Encoding = writeNumUtf16BytesForUtf8Encoding;
     return this;
   }
@@ -391,6 +390,9 @@ public final class FuryBuilder {
               + "use {} instead, or implement a custom {}.",
           ObjectStreamSerializer.class,
           Serializer.class);
+    }
+    if (writeNumUtf16BytesForUtf8Encoding == null) {
+      writeNumUtf16BytesForUtf8Encoding = language == Language.JAVA;
     }
     if (compatibleMode == CompatibleMode.COMPATIBLE) {
       checkClassVersion = false;

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTestBase.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTestBase.java
@@ -129,6 +129,16 @@ public abstract class FuryTestBase {
   }
 
   @DataProvider
+  public static Object[][] oneBoolOption() {
+    return new Object[][] {{false}, {true}};
+  }
+
+  @DataProvider
+  public static Object[][] twoBoolOptions() {
+    return new Object[][] {{false, false}, {true, false}, {false, true}, {true, true}};
+  }
+
+  @DataProvider
   public static Object[][] compressNumberAndCodeGen() {
     return new Object[][] {{false, false}, {true, false}, {false, true}, {true, true}};
   }

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -343,8 +343,7 @@ public class StringSerializerTest extends FuryTestBase {
       assertEquals(serializer.read(buffer), "abc你好");
       byte[] bytes = "abc你好".getBytes(StandardCharsets.UTF_8);
       byte UTF8 = 2;
-      buffer.writeVarUint64(((long) "abc你好".length() << 1) << 2 | UTF8);
-      buffer.writeInt32(bytes.length);
+      buffer.writeVarUint64((((long) bytes.length) << 2 | UTF8));
       buffer.writeBytes(bytes);
       assertEquals(serializer.read(buffer), "abc你好");
       assertEquals(buffer.readerIndex(), buffer.writerIndex());

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -190,6 +190,22 @@ public class StringSerializerTest extends FuryTestBase {
     assertEquals(a, b);
   }
 
+  @Test
+  public void testCompressedStringEstimatedWrongSize() {
+    Fury fury =
+        Fury.builder()
+            .withStringCompressed(true)
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(false)
+            .build();
+    // estimated 41 bytes, header needs 2 byte.
+    // encoded utf8 is 31 bytes, took 1 byte for header.
+    serDeCheck(fury, StringUtils.random(25, 47) + "你好");
+    // estimated 31 bytes, header needs 1 byte.
+    // encoded utf8 is 32 bytes, took 2 byte for header.
+    serDeCheck(fury, "hello, world. 你好，世界。");
+  }
+
   @Test(dataProvider = "stringCompress")
   public void testJavaString(boolean stringCompress) {
     Fury fury =

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -171,23 +171,19 @@ public class StringSerializerTest extends FuryTestBase {
   }
 
   /** Test for <a href="https://github.com/apache/fury/issues/1984">#1984</a> */
-  @Test
-  public void testJavaCompressedString() {
+  @Test(dataProvider = "oneBoolOption")
+  public void testJavaCompressedString(boolean b) {
     Fury fury =
         Fury.builder()
             .withStringCompressed(true)
+            .withWriteNumUtf16BytesForUtf8Encoding(b)
             .withLanguage(Language.JAVA)
             .requireClassRegistration(false)
             .build();
-
     Simple a =
         new Simple(
             "STG@ON DEMAND Solutions@GeoComputing Switch/ Hub@Digi Edgeport/216 – 16 port Serial Hub");
-
-    byte[] bytes = fury.serialize(a);
-
-    Simple b = (Simple) fury.deserialize(bytes);
-    assertEquals(a, b);
+    serDeCheck(fury, a);
   }
 
   @Test
@@ -195,6 +191,7 @@ public class StringSerializerTest extends FuryTestBase {
     Fury fury =
         Fury.builder()
             .withStringCompressed(true)
+            .withWriteNumUtf16BytesForUtf8Encoding(false)
             .withLanguage(Language.JAVA)
             .requireClassRegistration(false)
             .build();
@@ -206,10 +203,14 @@ public class StringSerializerTest extends FuryTestBase {
     serDeCheck(fury, "hello, world. 你好，世界。");
   }
 
-  @Test(dataProvider = "stringCompress")
-  public void testJavaString(boolean stringCompress) {
+  @Test(dataProvider = "twoBoolOptions")
+  public void testJavaString(boolean stringCompress, boolean writeNumUtf16BytesForUtf8Encoding) {
     Fury fury =
-        Fury.builder().withStringCompressed(stringCompress).requireClassRegistration(false).build();
+        Fury.builder()
+            .withStringCompressed(stringCompress)
+            .withWriteNumUtf16BytesForUtf8Encoding(writeNumUtf16BytesForUtf8Encoding)
+            .requireClassRegistration(false)
+            .build();
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     StringSerializer serializer = new StringSerializer(fury);
 
@@ -227,10 +228,15 @@ public class StringSerializerTest extends FuryTestBase {
         new String[] {"你好, Fury" + StringUtils.random(64), "你好, Fury" + StringUtils.random(64)});
   }
 
-  @Test(dataProvider = "stringCompress")
-  public void testJavaStringOffHeap(boolean stringCompress) {
+  @Test(dataProvider = "twoBoolOptions")
+  public void testJavaStringOffHeap(
+      boolean stringCompress, boolean writeNumUtf16BytesForUtf8Encoding) {
     Fury fury =
-        Fury.builder().withStringCompressed(stringCompress).requireClassRegistration(false).build();
+        Fury.builder()
+            .withStringCompressed(stringCompress)
+            .withWriteNumUtf16BytesForUtf8Encoding(writeNumUtf16BytesForUtf8Encoding)
+            .requireClassRegistration(false)
+            .build();
     MemoryBuffer buffer = MemoryUtils.wrap(ByteBuffer.allocateDirect(1024));
     Object o1 = "你好, Fury" + StringUtils.random(64);
     Object o2 =
@@ -347,9 +353,14 @@ public class StringSerializerTest extends FuryTestBase {
     }
   }
 
-  @Test
-  public void testReadUtf8String() {
-    Fury fury = Fury.builder().withStringCompressed(true).requireClassRegistration(false).build();
+  @Test(dataProvider = "oneBoolOption")
+  public void testReadUtf8String(boolean writeNumUtf16BytesForUtf8Encoding) {
+    Fury fury =
+        Fury.builder()
+            .withStringCompressed(true)
+            .withWriteNumUtf16BytesForUtf8Encoding(writeNumUtf16BytesForUtf8Encoding)
+            .requireClassRegistration(false)
+            .build();
     for (MemoryBuffer buffer :
         new MemoryBuffer[] {
           MemoryUtils.buffer(32), MemoryUtils.wrap(ByteBuffer.allocateDirect(2048))
@@ -359,7 +370,12 @@ public class StringSerializerTest extends FuryTestBase {
       assertEquals(serializer.read(buffer), "abc你好");
       byte[] bytes = "abc你好".getBytes(StandardCharsets.UTF_8);
       byte UTF8 = 2;
-      buffer.writeVarUint64((((long) bytes.length) << 2 | UTF8));
+      if (writeNumUtf16BytesForUtf8Encoding) {
+        buffer.writeVarUint64(((long) "abc你好".length() << 1) << 2 | UTF8);
+        buffer.writeInt32(bytes.length);
+      } else {
+        buffer.writeVarUint64((((long) bytes.length) << 2 | UTF8));
+      }
       buffer.writeBytes(bytes);
       assertEquals(serializer.read(buffer), "abc你好");
       assertEquals(buffer.readerIndex(), buffer.writerIndex());


### PR DESCRIPTION
## What does this PR do?

Currently fury serialize utf8 string in java will write num bytes of utf16 first, so that the deserializaiton can save one copy. 
But C++ and golang does not need this information. This PR makes the 4 bytes utf16 size header optional for utf8 encoding, so theat the xlang serialiation can use the standard fury string serialization spec, and align to other languages.

For performance consideration, this PR introduce `writeNumUtf16BytesForUtf8Encoding` which can perserve current behaviour.

## Related issues

#1890

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

This PR will introduce an extra copy for deserialization since we can't know the size of utf16 in advance before decoding utf8 string.
