### PR TITLE
style(cpp): rename logging level with "FURY_" prefix

### DIFF
--- a/cpp/fury/util/logging.cc
+++ b/cpp/fury/util/logging.cc
@@ -51,8 +51,10 @@ std::string GetCallTrace() {
 }
 
 std::unordered_map<FuryLogLevel, std::string> log_level_to_str = {
-    {FuryLogLevel::FURY_DEBUG, "DEBUG"},     {FuryLogLevel::FURY_INFO, "INFO"},
-    {FuryLogLevel::FURY_WARNING, "WARNING"}, {FuryLogLevel::FURY_ERROR, "ERROR"},
+    {FuryLogLevel::FURY_DEBUG, "DEBUG"},
+    {FuryLogLevel::FURY_INFO, "INFO"},
+    {FuryLogLevel::FURY_WARNING, "WARNING"},
+    {FuryLogLevel::FURY_ERROR, "ERROR"},
     {FuryLogLevel::FURY_FATAL, "FATAL"},
 };
 

--- a/cpp/fury/util/logging.cc
+++ b/cpp/fury/util/logging.cc
@@ -51,9 +51,9 @@ std::string GetCallTrace() {
 }
 
 std::unordered_map<FuryLogLevel, std::string> log_level_to_str = {
-    {FuryLogLevel::DEBUG, "DEBUG"},     {FuryLogLevel::INFO, "INFO"},
-    {FuryLogLevel::WARNING, "WARNING"}, {FuryLogLevel::ERR, "ERROR"},
-    {FuryLogLevel::FATAL, "FATAL"},
+    {FuryLogLevel::FURY_DEBUG, "DEBUG"},     {FuryLogLevel::FURY_INFO, "INFO"},
+    {FuryLogLevel::FURY_WARNING, "WARNING"}, {FuryLogLevel::FURY_ERROR, "ERROR"},
+    {FuryLogLevel::FURY_FATAL, "FATAL"},
 };
 
 std::string LogLevelAsString(FuryLogLevel level) {
@@ -65,26 +65,26 @@ std::string LogLevelAsString(FuryLogLevel level) {
 }
 
 FuryLogLevel FuryLog::GetLogLevel() {
-  FuryLogLevel severity_threshold = FuryLogLevel::INFO;
+  FuryLogLevel severity_threshold = FuryLogLevel::FURY_INFO;
   const char *var_value = std::getenv("FURY_LOG_LEVEL");
   if (var_value != nullptr) {
     std::string data = var_value;
     std::transform(data.begin(), data.end(), data.begin(), ::tolower);
     if (data == "debug") {
-      severity_threshold = FuryLogLevel::DEBUG;
+      severity_threshold = FuryLogLevel::FURY_DEBUG;
     } else if (data == "info") {
-      severity_threshold = FuryLogLevel::INFO;
+      severity_threshold = FuryLogLevel::FURY_INFO;
     } else if (data == "warning") {
-      severity_threshold = FuryLogLevel::WARNING;
+      severity_threshold = FuryLogLevel::FURY_WARNING;
     } else if (data == "error") {
-      severity_threshold = FuryLogLevel::ERR;
+      severity_threshold = FuryLogLevel::FURY_ERROR;
     } else if (data == "fatal") {
-      severity_threshold = FuryLogLevel::FATAL;
+      severity_threshold = FuryLogLevel::FURY_FATAL;
     } else {
-      FURY_LOG_INTERNAL(WARNING)
+      FURY_LOG_INTERNAL(FURY_WARNING)
           << "Unrecognized setting of FuryLogLevel=" << var_value;
     }
-    FURY_LOG_INTERNAL(INFO)
+    FURY_LOG_INTERNAL(FURY_INFO)
         << "Set ray log level from environment variable RAY_BACKEND_LOG_LEVEL"
         << " to " << static_cast<int>(severity_threshold);
   }
@@ -99,7 +99,7 @@ FuryLog::FuryLog(const char *file_name, int line_number, FuryLogLevel severity)
 }
 
 FuryLog::~FuryLog() {
-  if (severity_ == FuryLogLevel::FATAL) {
+  if (severity_ == FuryLogLevel::FURY_FATAL) {
     Stream() << "\n*** StackTrace Information ***\n" << ::fury::GetCallTrace();
     Stream() << std::endl;
     std::_Exit(EXIT_FAILURE);

--- a/cpp/fury/util/logging.h
+++ b/cpp/fury/util/logging.h
@@ -51,7 +51,7 @@ enum class FuryLogLevel {
 
 #define FURY_CHECK(condition)                                                  \
   if (!(condition))                                                            \
-  FURY_LOG_INTERNAL(FATAL) << " Check failed: " #condition " "
+  FURY_LOG_INTERNAL(FURY_FATAL) << " Check failed: " #condition " "
 
 #define FURY_CHECK_OP(left, op, right)                                         \
   do {                                                                         \

--- a/cpp/fury/util/logging.h
+++ b/cpp/fury/util/logging.h
@@ -32,11 +32,11 @@ std::string GetCallTrace();
 // Simple logging implementation to avoid introduce glog dependency.
 
 enum class FuryLogLevel {
-  DEBUG = -1,
-  INFO = 0,
-  WARNING = 1,
-  ERR = 2,
-  FATAL = 3
+  FURY_DEBUG = -1,
+  FURY_INFO = 0,
+  FURY_WARNING = 1,
+  FURY_ERROR = 2,
+  FURY_FATAL = 3
 };
 
 #define FURY_LOG_INTERNAL(level)                                               \

--- a/cpp/fury/util/logging_test.cc
+++ b/cpp/fury/util/logging_test.cc
@@ -28,8 +28,8 @@
 namespace fury {
 
 TEST(PrintLogTest, BasicLog) {
-  FURY_LOG(INFO) << "test info";
-  ASSERT_DEATH(FURY_LOG(FATAL) << "test fatal",
+  FURY_LOG(FURY_INFO) << "test info";
+  ASSERT_DEATH(FURY_LOG(FURY_FATAL) << "test fatal",
                "\\[.*\\] FATAL cpp/fury/util/logging_test.cc:.*: test fatal");
 }
 
@@ -70,7 +70,7 @@ std::string TestFunctionLevel2() { return TestFunctionLevel1(); }
 #ifndef _WIN32
 TEST(PrintLogTest, CallstackTraceTest) {
   auto ret = TestFunctionLevel2();
-  FURY_LOG(INFO) << "stack trace:\n" << ret;
+  FURY_LOG(FURY_INFO) << "stack trace:\n" << ret;
   // work for linux
   // EXPECT_TRUE(ret.find("TestFunctionLevel0") != std::string::npos);
   // work for mac

--- a/cpp/fury/util/string_util_test.cc
+++ b/cpp/fury/util/string_util_test.cc
@@ -286,7 +286,8 @@ TEST(UTF16ToUTF8Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(FURY_INFO) << "Standard library Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "Standard library Running Time: " << duration
+                        << " ns";
   } catch (const std::exception &e) {
     FURY_LOG(FURY_FATAL) << "Caught exception: " << e.what();
   }
@@ -523,10 +524,11 @@ TEST(UTF8ToUTF16Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(FURY_INFO) << "Standard Library Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "Standard Library Running Time: " << duration
+                        << " ns";
   } catch (const std::exception &e) {
     FURY_LOG(FURY_FATAL) << "Caught exception in standard library conversion: "
-                    << e.what();
+                         << e.what();
   }
 
   // BaseLine
@@ -541,7 +543,8 @@ TEST(UTF8ToUTF16Test, PerformanceTest) {
                         .count();
     FURY_LOG(FURY_INFO) << "BaseLine Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
-    FURY_LOG(FURY_FATAL) << "Caught exception in baseline conversion: " << e.what();
+    FURY_LOG(FURY_FATAL) << "Caught exception in baseline conversion: "
+                         << e.what();
   }
 
   // Optimized (SIMD)
@@ -557,7 +560,7 @@ TEST(UTF8ToUTF16Test, PerformanceTest) {
     FURY_LOG(FURY_INFO) << "SIMD Optimized Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
     FURY_LOG(FURY_FATAL) << "Caught exception in SIMD optimized conversion: "
-                    << e.what();
+                         << e.what();
   }
 }
 

--- a/cpp/fury/util/string_util_test.cc
+++ b/cpp/fury/util/string_util_test.cc
@@ -63,7 +63,7 @@ TEST(StringUtilTest, TestisAsciiFunctions) {
   auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                       end_time - start_time)
                       .count();
-  FURY_LOG(INFO) << "BaseLine Running Time: " << duration << " ns.";
+  FURY_LOG(FURY_INFO) << "BaseLine Running Time: " << duration << " ns.";
 
   start_time = std::chrono::high_resolution_clock::now();
   result = isAscii(testStr);
@@ -71,7 +71,7 @@ TEST(StringUtilTest, TestisAsciiFunctions) {
   duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time -
                                                                   start_time)
                  .count();
-  FURY_LOG(INFO) << "Optimized Running Time: " << duration << " ns.";
+  FURY_LOG(FURY_INFO) << "Optimized Running Time: " << duration << " ns.";
 
   EXPECT_TRUE(result);
 }
@@ -286,9 +286,9 @@ TEST(UTF16ToUTF8Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(INFO) << "Standard library Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "Standard library Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
-    FURY_LOG(FATAL) << "Caught exception: " << e.what();
+    FURY_LOG(FURY_FATAL) << "Caught exception: " << e.what();
   }
 
   // BaseLine
@@ -301,9 +301,9 @@ TEST(UTF16ToUTF8Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(INFO) << "Baseline Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "Baseline Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
-    FURY_LOG(FATAL) << "Caught exception: " << e.what();
+    FURY_LOG(FURY_FATAL) << "Caught exception: " << e.what();
   }
 
   // SIMD
@@ -316,9 +316,9 @@ TEST(UTF16ToUTF8Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(INFO) << "SIMD Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "SIMD Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
-    FURY_LOG(FATAL) << "Caught exception: " << e.what();
+    FURY_LOG(FURY_FATAL) << "Caught exception: " << e.what();
   }
 }
 
@@ -523,9 +523,9 @@ TEST(UTF8ToUTF16Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(INFO) << "Standard Library Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "Standard Library Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
-    FURY_LOG(FATAL) << "Caught exception in standard library conversion: "
+    FURY_LOG(FURY_FATAL) << "Caught exception in standard library conversion: "
                     << e.what();
   }
 
@@ -539,9 +539,9 @@ TEST(UTF8ToUTF16Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(INFO) << "BaseLine Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "BaseLine Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
-    FURY_LOG(FATAL) << "Caught exception in baseline conversion: " << e.what();
+    FURY_LOG(FURY_FATAL) << "Caught exception in baseline conversion: " << e.what();
   }
 
   // Optimized (SIMD)
@@ -554,9 +554,9 @@ TEST(UTF8ToUTF16Test, PerformanceTest) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         end_time - start_time)
                         .count();
-    FURY_LOG(INFO) << "SIMD Optimized Running Time: " << duration << " ns";
+    FURY_LOG(FURY_INFO) << "SIMD Optimized Running Time: " << duration << " ns";
   } catch (const std::exception &e) {
-    FURY_LOG(FATAL) << "Caught exception in SIMD optimized conversion: "
+    FURY_LOG(FURY_FATAL) << "Caught exception in SIMD optimized conversion: "
                     << e.what();
   }
 }


### PR DESCRIPTION
## What does this PR do?

Thus the duplicated macro problem could be solved.

## Related issues

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark