### PR TITLE
feat(java): Implement Zstd-based MetaCompressor

### DIFF
--- a/MYCONTRIBUTION.md
+++ b/MYCONTRIBUTION.md
@@ -1,0 +1,1 @@
+```Clean up PR descriptions by removing comments #2017```

--- a/MYCONTRIBUTION.md
+++ b/MYCONTRIBUTION.md
@@ -1,1 +1,7 @@
 ```Clean up PR descriptions by removing comments #2017```
+
+```Anubhab/1788 #2018
+```
+
+
+

--- a/fury-core/README.md
+++ b/fury-core/README.md
@@ -23,4 +23,4 @@ This module now includes support for compressing and decompressing type metadata
    public void processMetadata(byte[] metadata) {
        byte[] compressedMetadata = metaCompressor.compress(metadata);
        // ... use compressedMetadata ...
-   }
+   } 

--- a/fury-core/README.md
+++ b/fury-core/README.md
@@ -23,4 +23,4 @@ This module now includes support for compressing and decompressing type metadata
    public void processMetadata(byte[] metadata) {
        byte[] compressedMetadata = metaCompressor.compress(metadata);
        // ... use compressedMetadata ...
-   } 
+   }  

--- a/fury-core/README.md
+++ b/fury-core/README.md
@@ -1,0 +1,26 @@
+# fury-core Module
+
+This module provides core functionalities for the FURY project.
+
+## Zstd Compression Integration
+
+This module now includes support for compressing and decompressing type metadata using the Zstd compression library.
+
+**Features:**
+
+- **Improved Compression:** Zstd generally offers better compression ratios than the previous Deflater-based implementation.
+- **ZstdMetaCompressor:** A new `ZstdMetaCompressor` class has been implemented to handle Zstd compression and decompression.
+- **Unit Tests:** Unit tests have been added to verify the functionality and correctness of the `ZstdMetaCompressor`.
+
+**Usage:**
+
+- To use the `ZstdMetaCompressor`, inject it into your service classes:
+
+   ```java
+   @Autowired
+   private MetaCompressor metaCompressor; 
+
+   public void processMetadata(byte[] metadata) {
+       byte[] compressedMetadata = metaCompressor.compress(metadata);
+       // ... use compressedMetadata ...
+   }

--- a/fury-core/README.md
+++ b/fury-core/README.md
@@ -23,4 +23,4 @@ This module now includes support for compressing and decompressing type metadata
    public void processMetadata(byte[] metadata) {
        byte[] compressedMetadata = metaCompressor.compress(metadata);
        // ... use compressedMetadata ...
-   }  
+   }   

--- a/fury-core/pom.xml
+++ b/fury-core/pom.xml
@@ -1,0 +1,5 @@
+<dependency>
+    <groupId>com.github.luben</groupId>
+    <artifactId>zstd-jni</artifactId>
+    <version>1.5.2</version> 
+</dependency>

--- a/fury-core/src/main/java/com/example/fury/core/compression/ZstdMetaCompressor.java
+++ b/fury-core/src/main/java/com/example/fury/core/compression/ZstdMetaCompressor.java
@@ -1,0 +1,24 @@
+package com.example.fury.core.compression;
+
+import com.github.luben.zstd.Zstd;
+
+public class ZstdMetaCompressor implements MetaCompressor {
+
+    @Override
+    public byte[] compress(byte[] metadata) {
+        try {
+            return Zstd.compress(metadata);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to compress metadata: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public byte[] decompress(byte[] compressedMetadata) {
+        try {
+            return Zstd.decompress(compressedMetadata);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to decompress metadata: " + e.getMessage(), e);
+        }
+    }
+}

--- a/fury-core/src/main/java/com/example/fury/core/compression/ZstdMetaCompressorTest.java
+++ b/fury-core/src/main/java/com/example/fury/core/compression/ZstdMetaCompressorTest.java
@@ -1,0 +1,21 @@
+package com.example.fury.core.compression;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ZstdMetaCompressorTest {
+
+    private final MetaCompressor compressor = new ZstdMetaCompressor();
+
+    @Test
+    public void testCompressDecompress() {
+        byte[] originalData = "This is some sample metadata.".getBytes();
+        byte[] compressedData = compressor.compress(originalData);
+        byte[] decompressedData = compressor.decompress(compressedData);
+
+        assertArrayEquals(originalData, decompressedData);
+    }
+
+    // Add more test cases for different input sizes and edge cases
+}

--- a/fury-core/src/main/java/com/example/fury/service/MyService.java
+++ b/fury-core/src/main/java/com/example/fury/service/MyService.java
@@ -1,0 +1,17 @@
+package com.example.fury.service;
+
+import com.example.fury.core.compression.MetaCompressor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MyService {
+
+    @Autowired
+    private MetaCompressor metaCompressor;
+
+    public void processMetadata(byte[] metadata) {
+        byte[] compressedMetadata = metaCompressor.compress(metadata);
+        // ... use compressedMetadata ...
+    }
+}

--- a/scala/src/test/scala/org/apache/fury/serializer/scala/SerializerTest.scala
+++ b/scala/src/test/scala/org/apache/fury/serializer/scala/SerializerTest.scala
@@ -1,0 +1,24 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SerializerTest extends AnyFlatSpec with Matchers {
+  "ScalaCollectionSerializer" should "copy collections correctly" in {
+    val fury = new Fury()
+    val original = Seq(1, 2, 3)
+    val serializer = new ScalaCollectionSerializer[Int, Seq[Int]](fury, classOf[Seq[Int]])
+
+    val copy = serializer.copy(original)
+    copy shouldEqual original
+    copy should not be theSameInstanceAs (original)
+  }
+
+  "ScalaMapSerializer" should "copy maps correctly" in {
+    val fury = new Fury()
+    val original = Map("a" -> 1, "b" -> 2)
+    val serializer = new ScalaMapSerializer[String, Int, Map[String, Int]](fury, classOf[Map[String, Int]])
+
+    val copy = serializer.copy(original)
+    copy shouldEqual original
+    copy should not be theSameInstanceAs (original)
+  }
+}


### PR DESCRIPTION
# feat(java): Implement Zstd-based MetaCompressor 

This module provides core functionalities for the FURY project.

## Zstd Compression Integration

This module now includes support for compressing and decompressing type metadata using the Zstd compression library.

**Features:**

- **Improved Compression:** Zstd generally offers better compression ratios than the previous Deflater-based implementation.
- **ZstdMetaCompressor:** A new `ZstdMetaCompressor` class has been implemented to handle Zstd compression and decompression.
- **Unit Tests:** Unit tests have been added to verify the functionality and correctness of the `ZstdMetaCompressor`.

**Usage:**

- To use the `ZstdMetaCompressor`, inject it into your service classes:

   ```java
   @Autowired
   private MetaCompressor metaCompressor; 

   public void processMetadata(byte[] metadata) {
       byte[] compressedMetadata = metaCompressor.compress(metadata);
       // ... use compressedMetadata ...
   }