### PR TITLE
feat(python): unify type system between python and xlang serialization in pyfury

### DIFF
--- a/python/pyfury/_fury.py
+++ b/python/pyfury/_fury.py
@@ -30,6 +30,7 @@ from pyfury.resolver import (
     NOT_NULL_VALUE_FLAG,
 )
 from pyfury.util import is_little_endian, set_bit, get_bit, clear_bit
+from pyfury.type import TypeId
 
 try:
     import numpy as np
@@ -44,24 +45,21 @@ logger = logging.getLogger(__name__)
 
 
 MAGIC_NUMBER = 0x62D4
-DEFAULT_DYNAMIC_WRITE_STRING_ID = -1
+DEFAULT_DYNAMIC_WRITE_META_STR_ID = -1
 DYNAMIC_TYPE_ID = -1
 USE_CLASSNAME = 0
 USE_CLASS_ID = 1
 # preserve 0 as flag for class id not set in ClassInfo`
 NO_CLASS_ID = 0
-PYINT_CLASS_ID = 1
-PYFLOAT_CLASS_ID = 2
-PYBOOL_CLASS_ID = 3
-STRING_CLASS_ID = 4
-PICKLE_CLASS_ID = 5
-PICKLE_STRONG_CACHE_CLASS_ID = 6
-PICKLE_CACHE_CLASS_ID = 7
+INT64_CLASS_ID = TypeId.INT64
+FLOAT64_CLASS_ID = TypeId.FLOAT64
+BOOL_CLASS_ID = TypeId.BOOL
+STRING_CLASS_ID = TypeId.STRING
 # `NOT_NULL_VALUE_FLAG` + `CLASS_ID << 1` in little-endian order
-NOT_NULL_PYINT_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (PYINT_CLASS_ID << 9)
-NOT_NULL_PYFLOAT_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (PYFLOAT_CLASS_ID << 9)
-NOT_NULL_PYBOOL_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (PYBOOL_CLASS_ID << 9)
-NOT_NULL_STRING_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (STRING_CLASS_ID << 9)
+NOT_NULL_INT64_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (INT64_CLASS_ID << 8)
+NOT_NULL_FLOAT64_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (FLOAT64_CLASS_ID << 8)
+NOT_NULL_BOOL_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (BOOL_CLASS_ID << 8)
+NOT_NULL_STRING_FLAG = NOT_NULL_VALUE_FLAG & 0b11111111 | (STRING_CLASS_ID << 8)
 SMALL_STRING_THRESHOLD = 16
 
 
@@ -156,7 +154,7 @@ class Fury:
                 stacklevel=2,
             )
             self.pickler = Pickler(self.buffer)
-            self.unpickler = Unpickler(self.buffer)
+            self.unpickler = None
         else:
             self.pickler = _PicklerStub()
             self.unpickler = _UnpicklerStub()
@@ -263,32 +261,32 @@ class Fury:
             buffer.write_string(obj)
             return
         elif cls is int:
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_INT64_FLAG)
             buffer.write_varint64(obj)
             return
         elif cls is bool:
-            buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
+            buffer.write_int16(NOT_NULL_BOOL_FLAG)
             buffer.write_bool(obj)
             return
         if self.ref_resolver.write_ref_or_null(buffer, obj):
             return
         if classinfo is None:
             classinfo = self.class_resolver.get_classinfo(cls)
-        self.class_resolver.write_classinfo(buffer, classinfo)
+        self.class_resolver.write_typeinfo(buffer, classinfo)
         classinfo.serializer.write(buffer, obj)
 
     def serialize_nonref(self, buffer, obj):
         cls = type(obj)
         if cls is str:
-            buffer.write_varuint32(STRING_CLASS_ID << 1)
+            buffer.write_varuint32(STRING_CLASS_ID)
             buffer.write_string(obj)
             return
         elif cls is int:
-            buffer.write_varuint32(PYINT_CLASS_ID << 1)
+            buffer.write_varuint32(INT64_CLASS_ID)
             buffer.write_varint64(obj)
             return
         elif cls is bool:
-            buffer.write_varuint32(PYBOOL_CLASS_ID << 1)
+            buffer.write_varuint32(BOOL_CLASS_ID)
             buffer.write_bool(obj)
             return
         else:
@@ -380,7 +378,7 @@ class Fury:
         ref_id = ref_resolver.try_preserve_ref_id(buffer)
         # indicates that the object is first read.
         if ref_id >= NOT_NULL_VALUE_FLAG:
-            classinfo = self.class_resolver.read_classinfo(buffer)
+            classinfo = self.class_resolver.read_typeinfo(buffer)
             o = classinfo.serializer.read(buffer)
             ref_resolver.set_read_object(ref_id, o)
             return o
@@ -389,7 +387,7 @@ class Fury:
 
     def deserialize_nonref(self, buffer):
         """Deserialize not-null and non-reference object from buffer."""
-        classinfo = self.class_resolver.read_classinfo(buffer)
+        classinfo = self.class_resolver.read_typeinfo(buffer)
         return classinfo.serializer.read(buffer)
 
     def xdeserialize_ref(self, buffer, serializer=None):
@@ -448,7 +446,10 @@ class Fury:
     def handle_unsupported_read(self, buffer):
         in_band = buffer.read_bool()
         if in_band:
-            return self.unpickler.load()
+            unpickler = self.unpickler
+            if unpickler is None:
+                self.unpickler = unpickler = Unpickler(buffer)
+            return unpickler.load()
         else:
             assert self._unsupported_objects is not None
             return next(self._unsupported_objects)

--- a/python/pyfury/_registry.py
+++ b/python/pyfury/_registry.py
@@ -43,10 +43,8 @@ from pyfury.serializer import (
     Int16Serializer,
     Int32Serializer,
     Int64Serializer,
-    DynamicIntSerializer,
-    FloatSerializer,
-    DoubleSerializer,
-    DynamicFloatSerializer,
+    Float32Serializer,
+    Float64Serializer,
     StringSerializer,
     DateSerializer,
     TimestampSerializer,
@@ -60,6 +58,7 @@ from pyfury.serializer import (
     PickleCacheSerializer,
     PickleStrongCacheSerializer,
     PickleSerializer,
+    DataClassSerializer,
 )
 from pyfury._struct import ComplexObjectSerializer
 from pyfury.buffer import Buffer
@@ -78,13 +77,6 @@ from pyfury._fury import (
     DYNAMIC_TYPE_ID,
     # preserve 0 as flag for class id not set in ClassInfo`
     NO_CLASS_ID,
-    PYINT_CLASS_ID,
-    PYFLOAT_CLASS_ID,
-    PYBOOL_CLASS_ID,
-    STRING_CLASS_ID,
-    PICKLE_CLASS_ID,
-    PICKLE_STRONG_CACHE_CLASS_ID,
-    PICKLE_CACHE_CLASS_ID,
 )
 
 try:
@@ -168,7 +160,7 @@ class ClassResolver:
         self._hash_to_classinfo = dict()
         self._dynamic_written_metastr = []
         self._type_id_to_classinfo = dict()
-        self._type_id_counter = PICKLE_CACHE_CLASS_ID + 1
+        self._type_id_counter = 64
         self._dynamic_write_string_id = 0
         # hold objects to avoid gc, since `flat_hash_map/vector` doesn't
         # hold python reference.
@@ -181,60 +173,30 @@ class ClassResolver:
         self.typename_decoder = MetaStringDecoder("$", "_")
 
     def initialize(self):
+        self._initialize_xlang()
         if self.fury.language == Language.PYTHON:
             self._initialize_py()
-        else:
-            self._initialize_xlang()
 
     def _initialize_py(self):
         register = functools.partial(self._register_type, internal=True)
-        register(int, type_id=PYINT_CLASS_ID, serializer=Int64Serializer)
-        register(float, type_id=PYFLOAT_CLASS_ID, serializer=DoubleSerializer)
-        register(bool, type_id=PYBOOL_CLASS_ID, serializer=BooleanSerializer)
-        register(str, type_id=STRING_CLASS_ID, serializer=StringSerializer)
-        register(_PickleStub, type_id=PICKLE_CLASS_ID, serializer=PickleSerializer)
+        register(
+            _PickleStub,
+            type_id=PickleSerializer.PICKLE_CLASS_ID,
+            serializer=PickleSerializer,
+        )
         register(
             PickleStrongCacheStub,
-            type_id=PICKLE_STRONG_CACHE_CLASS_ID,
+            type_id=97,
             serializer=PickleStrongCacheSerializer(self.fury),
         )
         register(
             PickleCacheStub,
-            type_id=PICKLE_CACHE_CLASS_ID,
+            type_id=98,
             serializer=PickleCacheSerializer(self.fury),
         )
         register(type(None), serializer=NoneSerializer)
-        register(Int8Type, serializer=ByteSerializer)
-        register(Int16Type, serializer=Int16Serializer)
-        register(Int32Type, serializer=Int32Serializer)
-        register(Int64Type, serializer=Int64Serializer)
-        register(Float32Type, serializer=FloatSerializer)
-        register(Float64Type, serializer=DoubleSerializer)
-        register(datetime.date, serializer=DateSerializer)
-        register(datetime.datetime, serializer=TimestampSerializer)
-        register(bytes, serializer=BytesSerializer)
-        register(list, serializer=ListSerializer)
         register(tuple, serializer=TupleSerializer)
-        register(dict, serializer=MapSerializer)
-        register(set, serializer=SetSerializer)
-        register(enum.Enum, serializer=EnumSerializer)
         register(slice, serializer=SliceSerializer)
-        try:
-            import pyarrow as pa
-            from pyfury.format.serializer import (
-                ArrowRecordBatchSerializer,
-                ArrowTableSerializer,
-            )
-
-            register(pa.RecordBatch, serializer=ArrowRecordBatchSerializer)
-            register(pa.Table, serializer=ArrowTableSerializer)
-        except Exception:
-            pass
-        for size, ftype, type_id in PyArraySerializer.typecode_dict.values():
-            register(ftype, serializer=PyArraySerializer(self.fury, ftype, type_id))
-        register(array.array, serializer=DynamicPyArraySerializer)
-        if np:
-            register(np.ndarray, serializer=NDArraySerializer)
 
     def _initialize_xlang(self):
         register = functools.partial(self._register_type, internal=True)
@@ -243,18 +205,18 @@ class ClassResolver:
         register(Int16Type, type_id=TypeId.INT16, serializer=Int16Serializer)
         register(Int32Type, type_id=TypeId.INT32, serializer=Int32Serializer)
         register(Int64Type, type_id=TypeId.INT64, serializer=Int64Serializer)
-        register(int, type_id=DYNAMIC_TYPE_ID, serializer=DynamicIntSerializer)
+        register(int, type_id=TypeId.INT64, serializer=Int64Serializer)
         register(
             Float32Type,
             type_id=TypeId.FLOAT32,
-            serializer=FloatSerializer,
+            serializer=Float32Serializer,
         )
         register(
             Float64Type,
             type_id=TypeId.FLOAT64,
-            serializer=DoubleSerializer,
+            serializer=Float64Serializer,
         )
-        register(float, type_id=DYNAMIC_TYPE_ID, serializer=DynamicFloatSerializer)
+        register(float, type_id=TypeId.FLOAT64, serializer=Float64Serializer)
         register(str, type_id=TypeId.STRING, serializer=StringSerializer)
         # TODO(chaokunyang) DURATION DECIMAL
         register(
@@ -512,9 +474,19 @@ class ClassResolver:
             raise TypeUnregisteredError(f"{cls} not registered")
         logger.info("Class %s not registered", cls)
         serializer = self._create_serializer(cls)
-        type_id = (
-            NO_CLASS_ID if type(serializer) is not PickleSerializer else PICKLE_CLASS_ID
-        )
+        type_id = None
+        if self.language == Language.PYTHON:
+            if isinstance(serializer, EnumSerializer):
+                type_id = TypeId.NAMED_ENUM
+            elif type(serializer) is PickleSerializer:
+                type_id = PickleSerializer.PICKLE_CLASS_ID
+            if not self.require_registration:
+                if isinstance(serializer, DataClassSerializer):
+                    type_id = TypeId.NAMED_STRUCT
+        if type_id is None:
+            raise TypeUnregisteredError(
+                f"{cls} must be registered using `fury.register_type` API"
+            )
         return self.__register_type(
             cls,
             type_id=type_id,
@@ -544,33 +516,6 @@ class ClassResolver:
                 serializer = PickleSerializer(self.fury, cls)
         return serializer
 
-    def write_classinfo(self, buffer: Buffer, classinfo):
-        if classinfo.dynamic_type:
-            return
-        type_id = classinfo.type_id
-        if type_id != NO_CLASS_ID:
-            buffer.write_varuint32(type_id << 1)
-            return
-        buffer.write_varuint32(1)
-        self.metastring_resolver.write_meta_string_bytes(
-            buffer, classinfo.namespace_bytes
-        )
-        self.metastring_resolver.write_meta_string_bytes(
-            buffer, classinfo.typename_bytes
-        )
-
-    def read_classinfo(self, buffer):
-        header = buffer.read_varuint32()
-        if header & 0b1 == 0:
-            type_id = header >> 1
-            classinfo = self._type_id_to_classinfo[type_id]
-            if classinfo.serializer is None:
-                classinfo.serializer = self._create_serializer(classinfo.cls)
-            return classinfo
-        ns_metabytes = self.metastring_resolver.read_meta_string_bytes(buffer)
-        type_metabytes = self.metastring_resolver.read_meta_string_bytes(buffer)
-        return self._load_metabytes_to_classinfo(ns_metabytes, type_metabytes)
-
     def _load_metabytes_to_classinfo(self, ns_metabytes, type_metabytes):
         typeinfo = self._ns_type_to_classinfo.get((ns_metabytes, type_metabytes))
         if typeinfo is not None:
@@ -588,6 +533,8 @@ class ClassResolver:
         return classinfo
 
     def write_typeinfo(self, buffer, classinfo):
+        if classinfo.dynamic_type:
+            return
         type_id = classinfo.type_id
         internal_type_id = type_id & 0xFF
         buffer.write_varuint32(type_id)

--- a/python/pyfury/_registry.py
+++ b/python/pyfury/_registry.py
@@ -61,7 +61,6 @@ from pyfury.serializer import (
     DataClassSerializer,
 )
 from pyfury._struct import ComplexObjectSerializer
-from pyfury.buffer import Buffer
 from pyfury.meta.metastring import MetaStringEncoder, MetaStringDecoder
 from pyfury.type import (
     TypeId,

--- a/python/pyfury/_serializer.py
+++ b/python/pyfury/_serializer.py
@@ -26,10 +26,7 @@ from pyfury._fury import (
     NOT_NULL_BOOL_FLAG,
 )
 from pyfury.resolver import NOT_NULL_VALUE_FLAG, NULL_FLAG
-from pyfury.type import (
-    TypeId,
-    is_primitive_type,
-)
+from pyfury.type import is_primitive_type
 
 try:
     import numpy as np

--- a/python/pyfury/_serializer.py
+++ b/python/pyfury/_serializer.py
@@ -22,8 +22,8 @@ from typing import Dict, Iterable, Any
 
 from pyfury._fury import (
     NOT_NULL_STRING_FLAG,
-    NOT_NULL_PYINT_FLAG,
-    NOT_NULL_PYBOOL_FLAG,
+    NOT_NULL_INT64_FLAG,
+    NOT_NULL_BOOL_FLAG,
 )
 from pyfury.resolver import NOT_NULL_VALUE_FLAG, NULL_FLAG
 from pyfury.type import (
@@ -123,19 +123,7 @@ class Int64Serializer(Serializer):
         return buffer.read_varint64()
 
 
-class DynamicIntSerializer(CrossLanguageCompatibleSerializer):
-    def xwrite(self, buffer, value):
-        # TODO(chaokunyang) check value range and write type and value
-        buffer.write_varuint32(TypeId.INT64)
-        buffer.write_varint64(value)
-
-    def xread(self, buffer):
-        type_id = buffer.read_varuint32()
-        assert type_id == TypeId.INT64, type_id
-        return buffer.read_varint64()
-
-
-class FloatSerializer(CrossLanguageCompatibleSerializer):
+class Float32Serializer(CrossLanguageCompatibleSerializer):
     def write(self, buffer, value):
         buffer.write_float(value)
 
@@ -143,23 +131,11 @@ class FloatSerializer(CrossLanguageCompatibleSerializer):
         return buffer.read_float()
 
 
-class DoubleSerializer(CrossLanguageCompatibleSerializer):
+class Float64Serializer(CrossLanguageCompatibleSerializer):
     def write(self, buffer, value):
         buffer.write_double(value)
 
     def read(self, buffer):
-        return buffer.read_double()
-
-
-class DynamicFloatSerializer(CrossLanguageCompatibleSerializer):
-    def xwrite(self, buffer, value):
-        # TODO(chaokunyang) check value range and write type and value
-        buffer.write_varuint32(TypeId.FLOAT64)
-        buffer.write_double(value)
-
-    def xread(self, buffer):
-        type_id = buffer.read_varuint32()
-        assert type_id == TypeId.FLOAT64, type_id
         return buffer.read_double()
 
 
@@ -223,15 +199,15 @@ class CollectionSerializer(Serializer):
                 buffer.write_int16()
                 buffer.write_string(s)
             elif cls is int:
-                buffer.write_int16(NOT_NULL_PYINT_FLAG)
+                buffer.write_int16(NOT_NULL_INT64_FLAG)
                 buffer.write_varint64(s)
             elif cls is bool:
-                buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
+                buffer.write_int16(NOT_NULL_BOOL_FLAG)
                 buffer.write_bool(s)
             else:
                 if not self.ref_resolver.write_ref_or_null(buffer, s):
                     classinfo = self.class_resolver.get_classinfo(cls)
-                    self.class_resolver.write_classinfo(buffer, classinfo)
+                    self.class_resolver.write_typeinfo(buffer, classinfo)
                     classinfo.serializer.write(buffer, s)
 
     def read(self, buffer):
@@ -331,19 +307,19 @@ class MapSerializer(Serializer):
             else:
                 if not self.ref_resolver.write_ref_or_null(buffer, k):
                     classinfo = self.class_resolver.get_classinfo(key_cls)
-                    self.class_resolver.write_classinfo(buffer, classinfo)
+                    self.class_resolver.write_typeinfo(buffer, classinfo)
                     classinfo.serializer.write(buffer, k)
             value_cls = type(v)
             if value_cls is str:
                 buffer.write_int16(NOT_NULL_STRING_FLAG)
                 buffer.write_string(v)
             elif value_cls is int:
-                buffer.write_int16(NOT_NULL_PYINT_FLAG)
+                buffer.write_int16(NOT_NULL_INT64_FLAG)
                 buffer.write_varint64(v)
             else:
                 if not self.ref_resolver.write_ref_or_null(buffer, v):
                     classinfo = self.class_resolver.get_classinfo(value_cls)
-                    self.class_resolver.write_classinfo(buffer, classinfo)
+                    self.class_resolver.write_typeinfo(buffer, classinfo)
                     classinfo.serializer.write(buffer, v)
 
     def read(self, buffer):
@@ -400,7 +376,7 @@ class SliceSerializer(Serializer):
         start, stop, step = value.start, value.stop, value.step
         if type(start) is int:
             # TODO support varint128
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_INT64_FLAG)
             buffer.write_varint64(start)
         else:
             if start is None:
@@ -410,7 +386,7 @@ class SliceSerializer(Serializer):
                 self.fury.serialize_nonref(buffer, start)
         if type(stop) is int:
             # TODO support varint128
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_INT64_FLAG)
             buffer.write_varint64(stop)
         else:
             if stop is None:
@@ -420,7 +396,7 @@ class SliceSerializer(Serializer):
                 self.fury.serialize_nonref(buffer, stop)
         if type(step) is int:
             # TODO support varint128
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_INT64_FLAG)
             buffer.write_varint64(step)
         else:
             if step is None:

--- a/python/pyfury/resolver.py
+++ b/python/pyfury/resolver.py
@@ -161,7 +161,7 @@ class MapRefResolver(RefResolver):
         head_flag = buffer.read_int8()
         if head_flag == REF_FLAG:
             # read reference id and get object from reference resolver
-            ref_id = buffer.read_varint32()
+            ref_id = buffer.read_varuint32()
             self.read_object = self.get_read_object(ref_id)
             return REF_FLAG
         else:
@@ -178,7 +178,7 @@ class MapRefResolver(RefResolver):
         head_flag = buffer.read_int8()
         if head_flag == REF_FLAG:
             # read reference id and get object from reference resolver
-            ref_id = buffer.read_varint32()
+            ref_id = buffer.read_varuint32()
             self.read_object = self.get_read_object(id_=ref_id)
         else:
             self.read_object = None

--- a/python/pyfury/serializer.py
+++ b/python/pyfury/serializer.py
@@ -39,7 +39,7 @@ except ImportError:
     np = None
 
 from pyfury._fury import (
-    NOT_NULL_PYINT_FLAG,
+    NOT_NULL_INT64_FLAG,
     BufferObject,
 )
 
@@ -56,10 +56,8 @@ if ENABLE_FURY_CYTHON_SERIALIZATION:
         Int16Serializer,
         Int32Serializer,
         Int64Serializer,
-        DynamicIntSerializer,
-        FloatSerializer,
-        DoubleSerializer,
-        DynamicFloatSerializer,
+        Float32Serializer,
+        Float64Serializer,
         StringSerializer,
         DateSerializer,
         TimestampSerializer,
@@ -82,8 +80,8 @@ else:
         Int16Serializer,
         Int32Serializer,
         Int64Serializer,
-        FloatSerializer,
-        DoubleSerializer,
+        Float32Serializer,
+        Float64Serializer,
         StringSerializer,
         DateSerializer,
         TimestampSerializer,
@@ -96,8 +94,6 @@ else:
         SubMapSerializer,
         EnumSerializer,
         SliceSerializer,
-        DynamicIntSerializer,
-        DynamicFloatSerializer,
     )
 
 from pyfury.type import (
@@ -222,7 +218,7 @@ class PandasRangeIndexSerializer(Serializer):
         stop = value.stop
         step = value.step
         if type(start) is int:
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_INT64_FLAG)
             buffer.write_varint64(start)
         else:
             if start is None:
@@ -231,7 +227,7 @@ class PandasRangeIndexSerializer(Serializer):
                 buffer.write_int8(NOT_NULL_VALUE_FLAG)
                 fury.serialize_nonref(buffer, start)
         if type(stop) is int:
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_INT64_FLAG)
             buffer.write_varint64(stop)
         else:
             if stop is None:
@@ -240,7 +236,7 @@ class PandasRangeIndexSerializer(Serializer):
                 buffer.write_int8(NOT_NULL_VALUE_FLAG)
                 fury.serialize_nonref(buffer, stop)
         if type(step) is int:
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_INT64_FLAG)
             buffer.write_varint64(step)
         else:
             if step is None:
@@ -536,6 +532,7 @@ class DynamicPyArraySerializer(Serializer):
         return arr
 
     def write(self, buffer, value):
+        buffer.write_varuint32(PickleSerializer.PICKLE_CLASS_ID)
         self.fury.handle_unsupported_write(buffer, value)
 
     def read(self, buffer):
@@ -597,6 +594,7 @@ class Numpy1DArraySerializer(Serializer):
         return np.frombuffer(data, dtype=self.dtype)
 
     def write(self, buffer, value):
+        buffer.write_int8(PickleSerializer.PICKLE_CLASS_ID)
         self.fury.handle_unsupported_write(buffer, value)
 
     def read(self, buffer):
@@ -619,6 +617,7 @@ class NDArraySerializer(Serializer):
         raise NotImplementedError("Multi-dimensional array not supported currently")
 
     def write(self, buffer, value):
+        buffer.write_int8(PickleSerializer.PICKLE_CLASS_ID)
         self.fury.handle_unsupported_write(buffer, value)
 
     def read(self, buffer):
@@ -651,6 +650,8 @@ class BytesBufferObject(BufferObject):
 
 
 class PickleSerializer(Serializer):
+    PICKLE_CLASS_ID = 96
+
     def xwrite(self, buffer, value):
         raise NotImplementedError
 

--- a/python/pyfury/tests/test_serializer.py
+++ b/python/pyfury/tests/test_serializer.py
@@ -53,7 +53,7 @@ def test_float():
     assert ser_de(fury, -1.0) == -1.0
     assert ser_de(fury, 1 / 3) == 1 / 3
     serializer = fury.class_resolver.get_serializer(float)
-    assert type(serializer) is pyfury.DoubleSerializer
+    assert type(serializer) is pyfury.Float64Serializer
 
 
 def test_tuple():


### PR DESCRIPTION
## What does this PR do?

This pr unifies type system between python and xlang serialization in pyfury, so that we can remove duplicate code in pyfury, and lay the foundation for following features:
- [ ] implement protocol such as chunk based map serialization for pythobn and xlang serialization
- [ ] use python exsiting fastpath optimization in xlang serialization
- [ ] extend `DataClassSerializer` to support codegen based serialization for xlang

## Related issues
#1690

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
