### PR TITLE
fix(python): Fix missing parameters and old API names

### DIFF
--- a/python/pyfury/_fury.py
+++ b/python/pyfury/_fury.py
@@ -291,7 +291,7 @@ class Fury:
             return
         else:
             classinfo = self.class_resolver.get_classinfo(cls)
-            self.class_resolver.write_classinfo(buffer, classinfo)
+            self.class_resolver.write_typeinfo(buffer, classinfo)
             classinfo.serializer.write(buffer, obj)
 
     def xserialize_ref(self, buffer, obj, serializer=None):
@@ -459,7 +459,7 @@ class Fury:
             return
         if classinfo is None:
             classinfo = self.class_resolver.get_classinfo(type(value))
-        self.class_resolver.write_classinfo(buffer, classinfo)
+        self.class_resolver.write_typeinfo(buffer, classinfo)
         classinfo.serializer.write(buffer, value)
 
     def read_ref_pyobject(self, buffer):

--- a/python/pyfury/_serializer.py
+++ b/python/pyfury/_serializer.py
@@ -193,7 +193,7 @@ class CollectionSerializer(Serializer):
         for s in value:
             cls = type(s)
             if cls is str:
-                buffer.write_int16()
+                buffer.write_int16(NOT_NULL_STRING_FLAG)
                 buffer.write_string(s)
             elif cls is int:
                 buffer.write_int16(NOT_NULL_INT64_FLAG)


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
Fix missing parameters and old API names

``` python
self.class_resolver.write_classinfo(buffer, classinfo)
self.class_resolver.write_typeinfo(buffer, classinfo)
```

```python
  if cls is str:
      buffer.write_int16()
      buffer.write_int16(NOT_NULL_STRING_FLAG)
```

<!-- Describe the purpose of this PR. -->

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
