### PR TITLE
perf(java): try to eliminate virtual function call for the kv serialization of Map<String, String>

### DIFF
--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/StringMapSerializationSuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/StringMapSerializationSuite.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.benchmark;
+
+import static org.apache.commons.lang3.RandomStringUtils.random;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fury.Fury;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@BenchmarkMode(Mode.Throughput)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class StringMapSerializationSuite {
+  public static void main(String[] args) throws IOException {
+    if (args.length == 0) {
+      String commandLine =
+          "org.apache.fury.*StringMapSerializationSuite.* -f 1 -wi 5 -i 5 -t 1 -w 3s -r 3s -rf csv";
+      System.out.println(commandLine);
+      args = commandLine.split(" ");
+    }
+    Main.main(args);
+  }
+
+  @Benchmark
+  public Object serialize(MapState state) {
+    state.results[0] = state.fury.serialize(state.object1);
+    state.results[1] = state.fury.serialize(state.object2);
+    state.results[2] = state.fury.serialize(state.object3);
+    return state.results;
+  }
+
+  @Benchmark
+  public Object deserialize(MapState state) {
+    state.results[0] = state.fury.deserialize(state.bytes1);
+    state.results[1] = state.fury.deserialize(state.bytes2);
+    state.results[2] = state.fury.deserialize(state.bytes3);
+    return state.results;
+  }
+
+  @State(Scope.Thread)
+  public static class MapState {
+    @Param({"50"})
+    public int mapSize;
+
+    @Param({"8"})
+    public int stringKeySize;
+
+    @Param({"32"})
+    public int stringValueSize;
+
+    private Object object1;
+    private Object object2;
+    private Object object3;
+
+    private byte[] bytes1;
+    private byte[] bytes2;
+    private byte[] bytes3;
+
+    private Fury fury;
+
+    private Object[] results = new Object[3];
+
+    @Setup(Level.Trial)
+    public void setup() {
+      fury = Fury.builder().build();
+      Map map1 = new HashMap(mapSize);
+      // Let's assume that the benchmark results for 'various types of Maps' are almost identical to
+      // those for 'Maps containing various types of key-value pairs'.
+      // Mix various types of key-value pairs to interfere with JIT's dynamic optimization of
+      // polymorphism.
+      for (int i = 0; i < mapSize; i++) {
+        map1.put(random(stringKeySize), random(stringValueSize));
+      }
+      object1 = map1;
+      bytes1 = fury.serialize(map1);
+
+      Map map2 = new HashMap(mapSize);
+      for (int i = 0; i < mapSize; i++) {
+        map2.put(i, i * 2);
+      }
+      object2 = map2;
+      bytes2 = fury.serialize(map2);
+
+      Map map3 = new HashMap(mapSize);
+      for (int i = 0; i < mapSize; i++) {
+        map3.put((long) i + 99, i * 3L);
+      }
+      object3 = map3;
+      bytes3 = fury.serialize(map3);
+    }
+  }
+}

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
@@ -127,7 +127,7 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
   }
 
   /**
-   * this method try to eliminate the virtual function call and help JIT inline for java String type
+   * this method try to eliminate the virtual function call and help JIT inline for java String type.
    */
   private void tryFastSerialize(Serializer serializer, MemoryBuffer buffer, Object value) {
     if (serializer instanceof StringSerializer) {
@@ -139,15 +139,15 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
   }
 
   /**
-   * this method try to eliminate the virtual function call and help JIT inline for java String type
+   * this method try to eliminate the virtual function call and help JIT inline for java String type.
    */
   private Object tryFastDeserialize(Serializer serializer, MemoryBuffer buffer) {
-      if (serializer instanceof StringSerializer) {
-          StringSerializer stringSerializer = (StringSerializer) serializer;
-          return stringSerializer.read(buffer);
-      } else {
-          return serializer.read(buffer);
-      }
+    if (serializer instanceof StringSerializer) {
+      StringSerializer stringSerializer = (StringSerializer) serializer;
+      return stringSerializer.read(buffer);
+    } else {
+      return serializer.read(buffer);
+    }
   }
 
   @Override

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
@@ -127,7 +127,8 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
   }
 
   /**
-   * this method try to eliminate the virtual function call and help JIT inline for java String type.
+   * this method try to eliminate the virtual function call and help JIT inline for java String
+   * type.
    */
   private void tryFastSerialize(Serializer serializer, MemoryBuffer buffer, Object value) {
     if (serializer instanceof StringSerializer) {
@@ -139,7 +140,8 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
   }
 
   /**
-   * this method try to eliminate the virtual function call and help JIT inline for java String type.
+   * this method try to eliminate the virtual function call and help JIT inline for java String
+   * type.
    */
   private Object tryFastDeserialize(Serializer serializer, MemoryBuffer buffer) {
     if (serializer instanceof StringSerializer) {
@@ -790,9 +792,14 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
           classResolver.readClassInfo(buffer, valueClassInfoReadCache).getSerializer();
     }
     for (int i = 0; i < chunkSize; i++) {
-      Object key = trackKeyRef ? fury.readRef(buffer, keySerializer) : tryFastDeserialize(keySerializer, buffer);
+      Object key =
+          trackKeyRef
+              ? fury.readRef(buffer, keySerializer)
+              : tryFastDeserialize(keySerializer, buffer);
       Object value =
-          trackValueRef ? fury.readRef(buffer, valueSerializer) : tryFastDeserialize(valueSerializer, buffer);
+          trackValueRef
+              ? fury.readRef(buffer, valueSerializer)
+              : tryFastDeserialize(valueSerializer, buffer);
       map.put(key, value);
       size--;
     }
@@ -836,13 +843,18 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
     for (int i = 0; i < chunkSize; i++) {
       generics.pushGenericType(keyGenericType);
       fury.incDepth(1);
-      Object key = trackKeyRef ? fury.readRef(buffer, keySerializer) : tryFastDeserialize(keySerializer, buffer);
+      Object key =
+          trackKeyRef
+              ? fury.readRef(buffer, keySerializer)
+              : tryFastDeserialize(keySerializer, buffer);
       fury.incDepth(-1);
       generics.popGenericType();
       generics.pushGenericType(valueGenericType);
       fury.incDepth(1);
       Object value =
-          trackValueRef ? fury.readRef(buffer, valueSerializer) : tryFastDeserialize(valueSerializer, buffer);
+          trackValueRef
+              ? fury.readRef(buffer, valueSerializer)
+              : tryFastDeserialize(valueSerializer, buffer);
       fury.incDepth(-1);
       generics.popGenericType();
       map.put(key, value);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
@@ -131,7 +131,7 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
    * type.
    */
   private void tryFastSerialize(Serializer serializer, MemoryBuffer buffer, Object value) {
-    if (serializer instanceof StringSerializer) {
+    if (serializer.getClass() == StringSerializer.class) {
       StringSerializer stringSerializer = (StringSerializer) serializer;
       stringSerializer.write(buffer, (String) value);
     } else {
@@ -144,7 +144,7 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
    * type.
    */
   private Object tryFastDeserialize(Serializer serializer, MemoryBuffer buffer) {
-    if (serializer instanceof StringSerializer) {
+    if (serializer.getClass() == StringSerializer.class) {
       StringSerializer stringSerializer = (StringSerializer) serializer;
       return stringSerializer.read(buffer);
     } else {


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

Add fast path for the serialization of `Map<String, String>`.

## Related issues

Closes #2026 

## Does this PR introduce any user-facing change?

None

## Benchmark

Inline log:
serialize:
```
@ 159   org.apache.fury.serializer.collection.AbstractMapSerializer::writeJavaChunk (318 bytes)   inline (hot)
  // ...
  @ 218   org.apache.fury.serializer.collection.AbstractMapSerializer::tryFastSerialize (33 bytes)   inline (hot)
    @ 20   org.apache.fury.serializer.StringSerializer::write (7 bytes)   inline (hot)
      @ 3   org.apache.fury.serializer.StringSerializer::writeJavaString (73 bytes)   inline (hot)
        @ 69   org.apache.fury.serializer.StringSerializer::writeCharsString (41 bytes)   inline (hot)
          @ 4   org.apache.fury.memory.Platform::getObject (9 bytes)   inline (hot)
            @ 5   sun.misc.Unsafe::getObject (0 bytes)   (intrinsic)
          @ 15   org.apache.fury.util.StringUtils::isLatin (6 bytes)   inline (hot)
            @ 2   org.apache.fury.util.StringUtils::isLatin (125 bytes)   inline (hot)
          @ 26   org.apache.fury.serializer.StringSerializer::writeCharsLatin1 (168 bytes)   inline (hot)
            @ 1   org.apache.fury.memory.MemoryBuffer::writerIndex (5 bytes)   accessor
            @ 21   org.apache.fury.memory.MemoryBuffer::ensure (14 bytes)   inline (hot)
            @ 25   org.apache.fury.memory.MemoryBuffer::getHeapMemory (5 bytes)   accessor
            @ 36   org.apache.fury.memory.MemoryBuffer::_unsafeHeapWriterIndex (10 bytes)   inline (hot)
            @ 53   org.apache.fury.memory.LittleEndian::putVarUint36Small (61 bytes)   inline (hot)
            @ 164   org.apache.fury.memory.MemoryBuffer::_unsafeWriterIndex (6 bytes)   inline (hot)
  @ 245   org.apache.fury.serializer.collection.AbstractMapSerializer::tryFastSerialize (33 bytes)   inline (hot)
    @ 20   org.apache.fury.serializer.StringSerializer::write (7 bytes)   inline (hot)
      @ 3   org.apache.fury.serializer.StringSerializer::writeJavaString (73 bytes)   inline (hot)
        @ 69   org.apache.fury.serializer.StringSerializer::writeCharsString (41 bytes)   inline (hot)
          @ 4   org.apache.fury.memory.Platform::getObject (9 bytes)   inline (hot)
            @ 5   sun.misc.Unsafe::getObject (0 bytes)   (intrinsic)
          @ 15   org.apache.fury.util.StringUtils::isLatin (6 bytes)   inline (hot)
            @ 2   org.apache.fury.util.StringUtils::isLatin (125 bytes)   inline (hot)
          @ 26   org.apache.fury.serializer.StringSerializer::writeCharsLatin1 (168 bytes)   inline (hot)
            @ 1   org.apache.fury.memory.MemoryBuffer::writerIndex (5 bytes)   accessor
            @ 21   org.apache.fury.memory.MemoryBuffer::ensure (14 bytes)   inline (hot)
            @ 25   org.apache.fury.memory.MemoryBuffer::getHeapMemory (5 bytes)   accessor
            @ 36   org.apache.fury.memory.MemoryBuffer::_unsafeHeapWriterIndex (10 bytes)   inline (hot)
            @ 53   org.apache.fury.memory.LittleEndian::putVarUint36Small (61 bytes)   inline (hot)
            @ 164   org.apache.fury.memory.MemoryBuffer::_unsafeWriterIndex (6 bytes)   inline (hot)
  // ...
```
deserialize:
```
@ 145   org.apache.fury.serializer.collection.AbstractMapSerializer::readJavaChunk (218 bytes)   inline (hot)
  // ...
  @ 143   org.apache.fury.serializer.collection.AbstractMapSerializer::tryFastDeserialize (24 bytes)   inline (hot)
    @ 14   org.apache.fury.serializer.StringSerializer::read (6 bytes)   inline (hot)
      @ 2   org.apache.fury.serializer.StringSerializer::readJavaString (64 bytes)   inline (hot)
        @ 60   org.apache.fury.serializer.StringSerializer::readCharsString (89 bytes)   inline (hot)
          @ 1   org.apache.fury.memory.MemoryBuffer::readVarUint36Small (89 bytes)   inline (hot)
            @ 21   org.apache.fury.memory.MemoryBuffer::_unsafeGetInt64 (33 bytes)   inlining too deep
            @ 85   org.apache.fury.memory.MemoryBuffer::readVarUint36Slow (122 bytes)   inlining too deep
          @ 29   org.apache.fury.serializer.StringSerializer::readCharsLatin1 (113 bytes)   inline (hot)
            @ 2   org.apache.fury.memory.MemoryBuffer::checkReadableBytes (29 bytes)   inlining too deep
            @ 6   org.apache.fury.memory.MemoryBuffer::getHeapMemory (5 bytes)   accessor
            @ 20   org.apache.fury.memory.MemoryBuffer::_unsafeHeapReaderIndex (10 bytes)   inlining too deep
            @ 59   org.apache.fury.memory.MemoryBuffer::_increaseReaderIndexUnsafe (11 bytes)   inlining too deep
          @ 85   org.apache.fury.serializer.StringSerializer::newCharsStringZeroCopy (32 bytes)   inline (hot)
            @ 23   java.lang.String$$Lambda$17/2003855659::apply (19 bytes)   inlining too deep
  @ 167   org.apache.fury.serializer.collection.AbstractMapSerializer::tryFastDeserialize (24 bytes)   inline (hot)
    @ 14   org.apache.fury.serializer.StringSerializer::read (6 bytes)   inline (hot)
      @ 2   org.apache.fury.serializer.StringSerializer::readJavaString (64 bytes)   inline (hot)
        @ 60   org.apache.fury.serializer.StringSerializer::readCharsString (89 bytes)   inline (hot)
          @ 1   org.apache.fury.memory.MemoryBuffer::readVarUint36Small (89 bytes)   inline (hot)
            @ 21   org.apache.fury.memory.MemoryBuffer::_unsafeGetInt64 (33 bytes)   inlining too deep
            @ 85   org.apache.fury.memory.MemoryBuffer::readVarUint36Slow (122 bytes)   inlining too deep
          @ 29   org.apache.fury.serializer.StringSerializer::readCharsLatin1 (113 bytes)   inline (hot)
            @ 2   org.apache.fury.memory.MemoryBuffer::checkReadableBytes (29 bytes)   inlining too deep
            @ 6   org.apache.fury.memory.MemoryBuffer::getHeapMemory (5 bytes)   accessor
            @ 20   org.apache.fury.memory.MemoryBuffer::_unsafeHeapReaderIndex (10 bytes)   inlining too deep
            @ 59   org.apache.fury.memory.MemoryBuffer::_increaseReaderIndexUnsafe (11 bytes)   inlining too deep
          @ 85   org.apache.fury.serializer.StringSerializer::newCharsStringZeroCopy (32 bytes)   inline (hot)
            @ 23   java.lang.String$$Lambda$17/2003855659::apply (19 bytes)   inlining too deep
  // ...
```