### PR TITLE
fix(java): fix ImmutableCollections$SubList duplicate registration

### DIFF
--- a/integration_tests/jdk_compatibility_tests/src/test/java/org/apache/fury/integration_tests/JDKCompatibilityTest.java
+++ b/integration_tests/jdk_compatibility_tests/src/test/java/org/apache/fury/integration_tests/JDKCompatibilityTest.java
@@ -61,26 +61,54 @@ public class JDKCompatibilityTest {
       Assert.assertEquals(fury.deserialize(serialized), object);
       write("object_schema_compatible" + Platform.JAVA_VERSION, serialized);
     }
+    // 11Test the case for the user registration class
+    {
+      Fury fury = builder().build();
+      fury.register(CustomObject.class);
+      CustomObject customObject = createCustomObject();
+      Assert.assertEquals(createCustomObject(), customObject);
+      byte[] serialized = fury.serialize(customObject);
+      Assert.assertEquals(fury.deserialize(serialized), customObject);
+      write("custom_object_schema_consistent" + Platform.JAVA_VERSION, serialized);
+    }
+    {
+      Fury fury = builder().withCompatibleMode(CompatibleMode.COMPATIBLE).build();
+      fury.register(CustomObject.class);
+      CustomObject customObject = createCustomObject();
+      byte[] serialized = fury.serialize(customObject);
+      Assert.assertEquals(fury.deserialize(serialized), customObject);
+      write("custom_object_schema_compatible" + Platform.JAVA_VERSION, serialized);
+    }
   }
 
   @Test
   public void testSchemaConsist() throws IOException {
     Object object = createObject();
     Fury fury = builder().build();
+    fury.register(CustomObject.class);
     File dir = new File(".");
     File[] files = dir.listFiles((d, name) -> name.startsWith("object_schema_consistent"));
     assert files != null;
     check(object, fury, files);
+    CustomObject customObject = createCustomObject();
+    File[] files1 = dir.listFiles((d, name) -> name.startsWith("custom_object_schema_consistent"));
+    assert files1 != null;
+    check(customObject, fury, files1);
   }
 
   @Test
   public void testSchemaCompatible() throws IOException {
     Object object = createObject();
     Fury fury = builder().withCompatibleMode(CompatibleMode.COMPATIBLE).build();
+    fury.register(CustomObject.class);
     File dir = new File(".");
     File[] files = dir.listFiles((d, name) -> name.startsWith("object_schema_compatible"));
     assert files != null;
     check(object, fury, files);
+    CustomObject customObject = createCustomObject();
+    File[] files1 = dir.listFiles((d, name) -> name.startsWith("custom_object_schema_compatible"));
+    assert files1 != null;
+    check(customObject, fury, files1);
   }
 
   private static void check(Object object, Fury fury, File[] files) throws IOException {
@@ -105,5 +133,38 @@ public class JDKCompatibilityTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  static class CustomObject {
+    private String str;
+
+    public String getStr() {
+      return str;
+    }
+
+    public void setStr(String str) {
+      this.str = str;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      CustomObject entity = (CustomObject) o;
+      return str.equals(entity.str);
+    }
+
+    @Override
+    public int hashCode() {
+      return str.hashCode();
+    }
+  }
+
+  CustomObject createCustomObject() {
+    CustomObject customObject = new CustomObject();
+    customObject.setStr("hello");
+    return customObject;
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/SubListSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/SubListSerializers.java
@@ -38,7 +38,6 @@ public class SubListSerializers {
   private static final Class<?> SubListClass;
   private static final Class<?> RandomAccessSubListClass;
   private static final Class<?> ArrayListSubListClass;
-  private static final Class<?> ImmutableSubListClass;
 
   private interface Stub {}
 
@@ -63,22 +62,14 @@ public class SubListSerializers {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     }
-    Class<?> cls;
-    try {
-      cls = Class.forName("java.util.ImmutableCollections$SubList");
-    } catch (ClassNotFoundException e) {
-      class ImmutableSubListStub implements Stub {}
-
-      cls = ImmutableSubListStub.class;
-    }
-    ImmutableSubListClass = cls;
   }
 
   public static void registerSerializers(Fury fury, boolean preserveView) {
     ClassResolver classResolver = fury.getClassResolver();
+    // java.util.ImmutableCollections$SubList is already registered in ImmutableCollectionSerializers
     for (Class<?> cls :
         new Class[] {
-          SubListClass, RandomAccessSubListClass, ArrayListSubListClass, ImmutableSubListClass
+          SubListClass, RandomAccessSubListClass, ArrayListSubListClass
         }) {
       if (fury.trackingRef() && preserveView && fury.getConfig().getLanguage() == Language.JAVA) {
         classResolver.registerSerializer(cls, new SubListViewSerializer(fury, cls));

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/SubListSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/SubListSerializers.java
@@ -66,11 +66,10 @@ public class SubListSerializers {
 
   public static void registerSerializers(Fury fury, boolean preserveView) {
     ClassResolver classResolver = fury.getClassResolver();
-    // java.util.ImmutableCollections$SubList is already registered in ImmutableCollectionSerializers
+    // java.util.ImmutableCollections$SubList is already registered in
+    // ImmutableCollectionSerializers
     for (Class<?> cls :
-        new Class[] {
-          SubListClass, RandomAccessSubListClass, ArrayListSubListClass
-        }) {
+        new Class[] {SubListClass, RandomAccessSubListClass, ArrayListSubListClass}) {
       if (fury.trackingRef() && preserveView && fury.getConfig().getLanguage() == Language.JAVA) {
         classResolver.registerSerializer(cls, new SubListViewSerializer(fury, cls));
       } else {


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
fix ImmutableCollections$SubList duplicate registration

java.util.ImmutableCollections$SubList has been registered twice, resulting in different numbers of classIdGenerator across different JDK versions, which ultimately leads to serialization failures when crossing JDK versions.
<!-- Describe the purpose of this PR. -->

## Related issues
Closes #2070 
<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
