### PR TITLE
perf(java): Refactor field sorting in StructSerializer to cache transformed field names and avoid redundant computation

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -2198,10 +2198,9 @@ public final class MemoryBuffer {
     int remaining = size - readerIdx;
     if (remaining >= 8) {
       readerIndex = readerIdx + len;
-      long v =
-          UNSAFE.getLong(heapMemory, address + readerIdx)
-              & (0xffffffffffffffffL >>> ((8 - len) * 8));
-      return LITTLE_ENDIAN ? v : Long.reverseBytes(v);
+      long v = UNSAFE.getLong(heapMemory, address + readerIdx);
+      v = (LITTLE_ENDIAN ? v : Long.reverseBytes(v)) & (0xffffffffffffffffL >>> ((8 - len) * 8));
+      return v;
     }
     return slowReadBytesAsInt64(remaining, len);
   }

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -254,7 +254,7 @@ public class MetaStringEncoder {
     int charInd = 0;
     int charBitRemain = bitsPerChar;  // Remaining bits to process for the current character
     int mask;
-    do {
+    while(charInd < chars.length) {
       int charVal = (bitsPerChar == 5) ? charToValueLowerSpecial(chars[charInd])
         : charToValueLowerUpperDigitSpecial(chars[charInd]);
       // Calculate how many bits are remaining in the current byte
@@ -280,7 +280,7 @@ public class MetaStringEncoder {
         bitInd = 0;  // Reset bit index for the new byte
         charBitRemain -= nowByteRemain;  // Decrease the remaining bits for the character
       }
-    } while (charInd < chars.length);
+    }
 
     boolean stripLastChar = bytes.length * 8 >= totalBits + bitsPerChar;
     if (stripLastChar) {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -245,40 +245,45 @@ public class MetaStringEncoder {
   }
 
   private byte[] encodeGeneric(char[] chars, int bitsPerChar) {
-    // assert bitsPerChar > 0 && bitsPerChar < 33;
     int totalBits = chars.length * bitsPerChar + 1;
     int byteLength = (totalBits + 7) / 8;
     byte[] bytes = new byte[byteLength];
     int byteInd = 0;
-    int bitInd = 1;  // Start from the second bit (the first is reserved for the flag)
+    int bitInd = 1; // Start from the second bit (the first is reserved for the flag)
     int charInd = 0;
-    int charBitRemain = bitsPerChar;  // Remaining bits to process for the current character
+    int charBitRemain = bitsPerChar; // Remaining bits to process for the current character
     int mask;
-    while(charInd < chars.length) {
-      int charVal = (bitsPerChar == 5) ? charToValueLowerSpecial(chars[charInd])
-        : charToValueLowerUpperDigitSpecial(chars[charInd]);
+    while (charInd < chars.length) {
+      int charVal =
+          (bitsPerChar == 5)
+              ? charToValueLowerSpecial(chars[charInd])
+              : charToValueLowerUpperDigitSpecial(chars[charInd]);
       // Calculate how many bits are remaining in the current byte
       int nowByteRemain = 8 - bitInd;
       if (nowByteRemain >= charBitRemain) {
         // If the remaining bits in the current byte can fit the whole character value
-        mask = (1 << charBitRemain) - 1;  // Create a mask for the bits of the character
-        bytes[byteInd] |= (byte) ((charVal & mask) << (nowByteRemain - charBitRemain));  // Place the character bits into the byte
+        mask = (1 << charBitRemain) - 1; // Create a mask for the bits of the character
+        bytes[byteInd] |=
+            (byte)
+                ((charVal & mask)
+                    << (nowByteRemain - charBitRemain)); // Place the character bits into the byte
         bitInd += charBitRemain;
         if (bitInd == 8) {
-          // Move to the next byte if the current byte is filled
           ++byteInd;
           bitInd = 0;
         }
-        // Character has been fully placed in the current byte, move to the next character
         ++charInd;
-        charBitRemain = bitsPerChar;  // Reset the remaining bits for the next character
+        charBitRemain = bitsPerChar; // Reset the remaining bits for the next character
       } else {
         // If the remaining bits in the current byte are not enough to hold the whole character
-        mask = (1 << nowByteRemain) - 1;  // Create a mask for the current available bits in the byte
-        bytes[byteInd] |= (byte) ((charVal >> (charBitRemain - nowByteRemain)) & mask);  // Place part of the character bits into the byte
-        ++byteInd;  // Move to the next byte
-        bitInd = 0;  // Reset bit index for the new byte
-        charBitRemain -= nowByteRemain;  // Decrease the remaining bits for the character
+        mask = (1 << nowByteRemain) - 1; // Create a mask for the current available bits in the byte
+        bytes[byteInd] |=
+            (byte)
+                ((charVal >> (charBitRemain - nowByteRemain))
+                    & mask); // Place part of the character bits into the byte
+        ++byteInd; // Move to the next byte
+        bitInd = 0; // Reset bit index for the new byte
+        charBitRemain -= nowByteRemain; // Decrease the remaining bits for the character
       }
     }
 

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -245,26 +245,46 @@ public class MetaStringEncoder {
   }
 
   private byte[] encodeGeneric(char[] chars, int bitsPerChar) {
+    // assert bitsPerChar > 0 && bitsPerChar < 33;
     int totalBits = chars.length * bitsPerChar + 1;
-    int byteLength = (totalBits + 7) / 8; // Calculate number of needed bytes
+    int byteLength = (totalBits + 7) / 8;
     byte[] bytes = new byte[byteLength];
-    int currentBit = 1;
-    for (char c : chars) {
-      int value =
-          (bitsPerChar == 5) ? charToValueLowerSpecial(c) : charToValueLowerUpperDigitSpecial(c);
-      // Encode the value in bitsPerChar bits
-      for (int i = bitsPerChar - 1; i >= 0; i--) {
-        if ((value & (1 << i)) != 0) {
-          // Set the bit in the byte array
-          int bytePos = currentBit / 8;
-          int bitPos = currentBit % 8;
-          bytes[bytePos] |= (byte) (1 << (7 - bitPos));
+    int byteInd = 0;
+    int bitInd = 1;  // Start from the second bit (the first is reserved for the flag)
+    int charInd = 0;
+    int charBitRemain = bitsPerChar;  // Remaining bits to process for the current character
+    int mask;
+    do {
+      int charVal = (bitsPerChar == 5) ? charToValueLowerSpecial(chars[charInd])
+        : charToValueLowerUpperDigitSpecial(chars[charInd]);
+      // Calculate how many bits are remaining in the current byte
+      int nowByteRemain = 8 - bitInd;
+      if (nowByteRemain >= charBitRemain) {
+        // If the remaining bits in the current byte can fit the whole character value
+        mask = (1 << charBitRemain) - 1;  // Create a mask for the bits of the character
+        bytes[byteInd] |= (byte) ((charVal & mask) << (nowByteRemain - charBitRemain));  // Place the character bits into the byte
+        bitInd += charBitRemain;
+        if (bitInd == 8) {
+          // Move to the next byte if the current byte is filled
+          ++byteInd;
+          bitInd = 0;
         }
-        currentBit++;
+        // Character has been fully placed in the current byte, move to the next character
+        ++charInd;
+        charBitRemain = bitsPerChar;  // Reset the remaining bits for the next character
+      } else {
+        // If the remaining bits in the current byte are not enough to hold the whole character
+        mask = (1 << nowByteRemain) - 1;  // Create a mask for the current available bits in the byte
+        bytes[byteInd] |= (byte) ((charVal >> (charBitRemain - nowByteRemain)) & mask);  // Place part of the character bits into the byte
+        ++byteInd;  // Move to the next byte
+        bitInd = 0;  // Reset bit index for the new byte
+        charBitRemain -= nowByteRemain;  // Decrease the remaining bits for the character
       }
-    }
+    } while (charInd < chars.length);
+
     boolean stripLastChar = bytes.length * 8 >= totalBits + bitsPerChar;
     if (stripLastChar) {
+      // Mark the first byte as indicating a stripped character
       bytes[0] = (byte) (bytes[0] | 0x80);
     }
     return bytes;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.fury.Fury;
 import org.apache.fury.config.Language;
 import org.apache.fury.exception.ClassNotCompatibleException;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
@@ -24,11 +24,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.fury.Fury;
 import org.apache.fury.config.Language;
 import org.apache.fury.exception.ClassNotCompatibleException;
@@ -84,7 +84,10 @@ public class StructSerializer<T> extends Serializer<T> {
     this.constructor = ctr;
     fieldAccessors =
         Descriptor.getFields(cls).stream()
-            .map(f -> new AbstractMap.SimpleEntry<>(f, StringUtils.lowerCamelToLowerUnderscore(f.getName())))
+            .map(
+                f ->
+                    new AbstractMap.SimpleEntry<>(
+                        f, StringUtils.lowerCamelToLowerUnderscore(f.getName())))
             .sorted(Map.Entry.comparingByValue())
             .map(Map.Entry::getKey)
             .map(FieldAccessor::createAccessor)

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
@@ -21,6 +21,7 @@ package org.apache.fury.serializer;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
@@ -83,7 +83,9 @@ public class StructSerializer<T> extends Serializer<T> {
     this.constructor = ctr;
     fieldAccessors =
         Descriptor.getFields(cls).stream()
-            .sorted(Comparator.comparing(f -> StringUtils.lowerCamelToLowerUnderscore(f.getName())))
+            .map(f -> new AbstractMap.SimpleEntry<>(f, StringUtils.lowerCamelToLowerUnderscore(f.getName())))
+            .sorted(Map.Entry.comparingByValue())
+            .map(Map.Entry::getKey)
             .map(FieldAccessor::createAccessor)
             .toArray(FieldAccessor[]::new);
     fieldGenerics = buildFieldGenerics(fury, TypeRef.of(cls), fieldAccessors);


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR refactors the field sorting in `StructSerializer.java` by caching transformed field names to avoid redundant computations during sorting. The `lowerCamelToLowerUnderscore` transformation is now applied once per field instead of multiple times.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
