### PR TITLE
perf(java): Refactor ThreadPoolFury to improve performance

### DIFF
--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/ThreadPoolFurySuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/ThreadPoolFurySuite.java
@@ -1,5 +1,6 @@
 package org.apache.fury.benchmark;
 
+import java.io.IOException;
 import org.apache.fury.Fury;
 import org.apache.fury.ThreadSafeFury;
 import org.apache.fury.config.CompatibleMode;
@@ -18,55 +19,55 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.io.IOException;
-
 @BenchmarkMode(Mode.SingleShotTime)
 @CompilerControl(value = CompilerControl.Mode.INLINE)
 @State(Scope.Benchmark)
 @OutputTimeUnit(java.util.concurrent.TimeUnit.MILLISECONDS)
 public class ThreadPoolFurySuite {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ThreadPoolFurySuite.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ThreadPoolFurySuite.class);
 
+  private ThreadSafeFury fury =
+      Fury.builder()
+          .withLanguage(Language.JAVA)
+          .requireClassRegistration(false)
+          .withJdkClassSerializableCheck(false)
+          .withRefTracking(false)
+          .withCompatibleMode(CompatibleMode.COMPATIBLE)
+          .withAsyncCompilation(true)
+          .withRefTracking(true)
+          .buildThreadSafeFuryPool(10, 60);
 
-    private ThreadSafeFury fury = Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(false)
-            .withJdkClassSerializableCheck(false).withRefTracking(false)
-            .withCompatibleMode(CompatibleMode.COMPATIBLE).withAsyncCompilation(true).withRefTracking(true)
-            .buildThreadSafeFuryPool(10, 60);
+  private static StructBenchmark.NumericStruct struct;
 
+  static {
+    struct = StructBenchmark.NumericStruct.build();
+    struct.f1 = 1;
+    struct.f2 = 2;
+    struct.f3 = 3;
+    struct.f4 = 4;
+    struct.f5 = 5;
+    struct.f6 = 6;
+    struct.f7 = 7;
+    struct.f8 = 8;
+  }
 
-    private static StructBenchmark.NumericStruct struct;
+  @Benchmark()
+  @Threads(10000)
+  public void testObjectPool(Blackhole bh) {
+    bh.consume(fury.serialize(struct));
+  }
 
-    static {
-        struct = StructBenchmark.NumericStruct.build();
-        struct.f1 = 1;
-        struct.f2 = 2;
-        struct.f3 = 3;
-        struct.f4 = 4;
-        struct.f5 = 5;
-        struct.f6 = 6;
-        struct.f7 = 7;
-        struct.f8 = 8;
+  @TearDown
+  public void tearDown() {}
+
+  public static void main(String[] args) throws IOException {
+    if (args.length == 0) {
+      String commandLine =
+          "org.apache.fury.*ObjectPoolBenchmark.* -f 1 -wi 0 -i 5 -w 2s -r 2s -rf csv";
+      System.out.println(commandLine);
+      args = commandLine.split(" ");
     }
-
-    @Benchmark()
-    @Threads(10000)
-    public void testObjectPool(Blackhole bh) {
-        bh.consume(fury.serialize(struct));
-    }
-
-    @TearDown
-    public void tearDown() {
-    }
-
-    public static void main(String[] args) throws IOException {
-        if (args.length == 0) {
-            String commandLine =
-                    "org.apache.fury.*ObjectPoolBenchmark.* -f 1 -wi 0 -i 5 -w 2s -r 2s -rf csv";
-            System.out.println(commandLine);
-            args = commandLine.split(" ");
-        }
-        Main.main(args);
-    }
-
+    Main.main(args);
+  }
 }

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/ThreadPoolFurySuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/ThreadPoolFurySuite.java
@@ -1,0 +1,72 @@
+package org.apache.fury.benchmark;
+
+import org.apache.fury.Fury;
+import org.apache.fury.ThreadSafeFury;
+import org.apache.fury.config.CompatibleMode;
+import org.apache.fury.config.Language;
+import org.apache.fury.logging.Logger;
+import org.apache.fury.logging.LoggerFactory;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+@State(Scope.Benchmark)
+@OutputTimeUnit(java.util.concurrent.TimeUnit.MILLISECONDS)
+public class ThreadPoolFurySuite {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ThreadPoolFurySuite.class);
+
+
+    private ThreadSafeFury fury = Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(false)
+            .withJdkClassSerializableCheck(false).withRefTracking(false)
+            .withCompatibleMode(CompatibleMode.COMPATIBLE).withAsyncCompilation(true).withRefTracking(true)
+            .buildThreadSafeFuryPool(10, 60);
+
+
+    private static StructBenchmark.NumericStruct struct;
+
+    static {
+        struct = StructBenchmark.NumericStruct.build();
+        struct.f1 = 1;
+        struct.f2 = 2;
+        struct.f3 = 3;
+        struct.f4 = 4;
+        struct.f5 = 5;
+        struct.f6 = 6;
+        struct.f7 = 7;
+        struct.f8 = 8;
+    }
+
+    @Benchmark()
+    @Threads(10000)
+    public void testObjectPool(Blackhole bh) {
+        bh.consume(fury.serialize(struct));
+    }
+
+    @TearDown
+    public void tearDown() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length == 0) {
+            String commandLine =
+                    "org.apache.fury.*ObjectPoolBenchmark.* -f 1 -wi 0 -i 5 -w 2s -r 2s -rf csv";
+            System.out.println(commandLine);
+            args = commandLine.split(" ");
+        }
+        Main.main(args);
+    }
+
+}

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/ThreadPoolFurySuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/ThreadPoolFurySuite.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.fury.benchmark;
 
 import java.io.IOException;


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
After testing, it was observed that ​ThreadPoolFury​ experiences prolonged blocking during cold starts under high-concurrency scenarios. Analysis revealed that improper usage of locks in ​ClassLoaderFuryPooled​ was the root cause. This PR refactors the implementation of ​ClassLoaderFuryPooled​ by significantly reducing the granularity of locks, thereby drastically minimizing blocking time during cold starts.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->
[](url)https://github.com/apache/fury/issues/2087
## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
CPU:9950X 
Class:org.apache.fury.benchmark.ThreadPoolFurySuite.java
old:
  Percentiles, ms/op:
      p(0.0000) =      0.001 ms/op
     p(50.0000) =      0.001 ms/op
     p(90.0000) =   1587.388 ms/op
     p(95.0000) =   1587.388 ms/op
     p(99.0000) =   1587.388 ms/op
     p(99.9000) =   1587.388 ms/op
     p(99.9900) =   1587.388 ms/op
     p(99.9990) =   1587.388 ms/op
     p(99.9999) =   1587.388 ms/op
    p(100.0000) =   1587.388 ms/op

new:
  Percentiles, ms/op:
      p(0.0000) =      0.001 ms/op
     p(50.0000) =      0.001 ms/op
     p(90.0000) =     62.746 ms/op
     p(95.0000) =     62.746 ms/op
     p(99.0000) =     62.746 ms/op
     p(99.9000) =     62.746 ms/op
     p(99.9900) =     62.746 ms/op
     p(99.9990) =     62.746 ms/op
     p(99.9999) =     62.746 ms/op
    p(100.0000) =     62.746 ms/op
