### PR TITLE
fix(java): fix disallowed.txt check in windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         run: ./ci/run_ci.sh java${{ matrix.java-version }}
 
   java21_windows:
-    name: Java 21 CI on Windows
+    name: Windows Java 21 CI
     runs-on: windows-2022
     env:
       MY_VAR: "PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,26 @@ jobs:
         run: ./ci/run_ci.sh install_pyfury
       - name: Run CI with Maven
         run: ./ci/run_ci.sh java${{ matrix.java-version }}
+
+  java21_windows:
+    name: Java 21 CI on Windows
+    runs-on: windows-2022
+    env:
+      MY_VAR: "PATH"
+    strategy:
+      matrix:
+        java-version: ["21"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: "temurin"
+      - name: Run CI with Maven
+        shell: bash
+        run: ./ci/run_ci.sh windows_java21
+
   graalvm:
     name: GraalVM CI
     runs-on: ubuntu-latest
@@ -113,6 +133,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Build native image and run
+        shell: bash
         run: ./ci/run_ci.sh graalvm_test
 
   scala:

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -162,6 +162,19 @@ jdk17_plus_tests() {
   echo "Executing latest_jdk_tests succeeds"
 }
 
+windows_java21_test() {
+  java -version
+  echo "Executing fury java tests"
+  cd "$ROOT/java"
+  set +e
+  mvn -T10 --batch-mode --no-transfer-progress test -Dtest=!org.apache.fury.CrossLanguageTest install -pl '!fury-format,!fury-testsuite'
+  testcode=$?
+  if [[ $testcode -ne 0 ]]; then
+    exit $testcode
+  fi
+  echo "Executing fury java tests succeeds"
+}
+
 case $1 in
     java8)
       echo "Executing fury java tests"
@@ -191,6 +204,9 @@ case $1 in
     ;;
     java21)
       jdk17_plus_tests
+    ;;
+    windows_java21)
+      windows_java21_test
     ;;
     integration_tests)
       echo "Install jdk"


### PR DESCRIPTION

## What does this PR do?
- add windows ci for java21
- Fix sha256 check error on windows:
![Image](https://github.com/user-attachments/assets/b082fc7a-c929-42fc-a910-707f604251f4)
## Related issues

Closes #2100

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
