### PR TITLE
chore(java): use the SHA256_HASH field value directly.

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/reflect/ReflectionUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/reflect/ReflectionUtils.java
@@ -292,6 +292,16 @@ public class ReflectionUtils {
     }
   }
 
+  public static Object getDeclaredStaticFieldValue(Class<?> cls, String fieldName) {
+    try {
+      Field declaredField = getDeclaredField(cls, fieldName);
+      declaredField.setAccessible(true);
+      return declaredField.get(null);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("Unreachable");
+    }
+  }
+
   /**
    * Return a field named <code>fieldName</code> from <code>cls</code>. Search parent class if not
    * found.

--- a/java/fury-core/src/test/java/org/apache/fury/resolver/DisallowedListTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/resolver/DisallowedListTest.java
@@ -33,6 +33,7 @@ import org.apache.fury.FuryTestBase;
 import org.apache.fury.config.Language;
 import org.apache.fury.exception.InsecureException;
 import org.apache.fury.memory.Platform;
+import org.apache.fury.reflect.ReflectionUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -40,8 +41,12 @@ public class DisallowedListTest extends FuryTestBase {
 
   @Test
   public void testCalculateSHA256() throws Exception {
+    final String disallowedListTxtPath =
+        (String)
+            ReflectionUtils.getDeclaredStaticFieldValue(
+                DisallowedList.class, "DISALLOWED_LIST_TXT_PATH");
     try (InputStream is =
-        DisallowedList.class.getClassLoader().getResourceAsStream("fury/disallowed.txt")) {
+        DisallowedList.class.getClassLoader().getResourceAsStream(disallowedListTxtPath)) {
       assert is != null;
       Set<String> set =
           new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
@@ -60,8 +65,11 @@ public class DisallowedListTest extends FuryTestBase {
         hexString.append(hex);
       }
       System.out.println("SHA256 HASH for disallowed.txt is " + hexString);
+
       Assert.assertEquals(
-          hexString.toString(), "53ecb405085d795d45ce033cd4f1055ae06247a5dbaa617ecd20e4aac4303f60");
+          hexString.toString(),
+          ReflectionUtils.getDeclaredStaticFieldValue(DisallowedList.class, "SHA256_HASH"),
+          "Please update `DisallowedList#SHA256_HASH` with the above output hash value.");
     }
   }
 


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
1. Directly use the `DisallowedList#DISALLOWED_LIST_TXT_PATH` value in `DisallowedListTest#testCalculateSHA256`.
2. Directly use the `DisallowedList#SHA256_HASH` value in `DisallowedListTest#testCalculateSHA256`.

Reduce manual maintenance costs :smile: 

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
