### PR TITLE
fix(java): ensure readVarUint36Small reads full bits regardless of remaining buffer size

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1800,7 +1800,7 @@ public final class MemoryBuffer {
           result |= (b & 0x7F) << 21;
           if ((b & 0x80) != 0) {
             b = readByte();
-            result |= (b & 0x7F) << 28;
+            result |= (b & 0xFF) << 28;
           }
         }
       }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of PR titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR fixes the inconsistent behavior of `readVarUint36Small()` when reading from buffers of different remaining sizes.  
- Aligns the fast path and slow path so both read the full 36 bits.  
- Updates the bit‐extraction in the slow path (`readVarUint36Slow()`) to match the fast path’s handling of the high‐order bits.  

## Related issues

- #2110

## Does this PR introduce any user‐facing change?

No user‐facing changes are introduced.  
- [ ] Does this PR introduce any public API change?  
- [ ] Does this PR introduce any binary protocol compatibility change?  

## Benchmark

No measurable performance impact is expected, as the fix only adjusts bit extraction logic without altering code paths.  
Benchmark