### PR TITLE
fix(java): ensure FuryObjectInputStream.read never returns 0 when length>0 #2204

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
@@ -894,7 +894,8 @@ public class ObjectStreamSerializer extends AbstractObjectSerializer {
         throw new IndexOutOfBoundsException();
       }
       int remaining = buffer.remaining();
-      if (remaining < length) {
+      // When remaining = 0, also force to refill buffer to avoid getting stuck
+      if (remaining > 0 && remaining < length) {
         buffer.readBytes(buf, offset, remaining);
         return remaining;
       } else {


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->

Ensure FuryObjectInputStream.read never returns 0 when length>0, so that when outer logic attempts to read in a while loop, it won't get stuck or throw exception.

## Related Issues
#2204 

## Does this PR introduce any user-facing change?

No.

## Benchmark

No measurable performance impact is expected.

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
