### PR TITLE
fix(java): Fix empty string processing in MetaStringBytes

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaString.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaString.java
@@ -55,7 +55,14 @@ public class MetaString {
       }
       throw new IllegalArgumentException("Encoding flag not recognized: " + value);
     }
+
+    public static Encoding forEmptyStr() {
+      return UTF_8;
+    }
   }
+
+  public static final MetaString EMPTY =
+      new MetaString("", Encoding.forEmptyStr(), '\0', '\0', new byte[0]);
 
   private final String string;
   private final Encoding encoding;

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringBytes.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringBytes.java
@@ -30,6 +30,7 @@ import org.apache.fury.util.MurmurHash3;
 @Internal
 public final class MetaStringBytes {
   static final short DEFAULT_DYNAMIC_WRITE_STRING_ID = -1;
+  public static final MetaStringBytes EMPTY = MetaStringBytes.of(MetaString.EMPTY);
   private static final int HEADER_MASK = 0xff;
 
   final byte[] bytes;

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringResolver.java
@@ -222,8 +222,12 @@ public final class MetaStringResolver {
   }
 
   private MetaStringBytes readSmallMetaStringBytes(MemoryBuffer buffer, int len) {
-    long v1, v2 = 0;
     byte encoding = buffer.readByte();
+    if (len == 0) {
+      assert encoding == MetaString.Encoding.UTF_8.getValue();
+      return MetaStringBytes.EMPTY;
+    }
+    long v1, v2 = 0;
     if (len <= 8) {
       v1 = buffer.readBytesAsInt64(len);
     } else {
@@ -239,8 +243,12 @@ public final class MetaStringResolver {
 
   private MetaStringBytes readSmallMetaStringBytes(
       MemoryBuffer buffer, MetaStringBytes cache, int len) {
-    long v1, v2 = 0;
     byte encoding = buffer.readByte();
+    if (len == 0) {
+      assert encoding == MetaString.Encoding.UTF_8.getValue();
+      return MetaStringBytes.EMPTY;
+    }
+    long v1, v2 = 0;
     if (len <= 8) {
       v1 = buffer.readBytesAsInt64(len);
     } else {


### PR DESCRIPTION
## What does this PR do?
This PR fixes issue #2096 by improving the handling of empty strings in MetaStringBytes. The primary changes are:

1. Explicitly defining that empty strings will use UTF-8 encoding for meta string encoding
2. Adding a dedicated constant for empty MetaStringBytes: `public static final MetaStringBytes EMPTY = MetaStringBytes.of(MetaString.EMPTY)`
3. Adding a length check to prevent potential buffer reading issues when length is zero

These changes ensure that empty strings are handled consistently throughout the codebase and prevent potential errors when processing empty strings during serialization and deserialization.

## Related issues
- #2096

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

## Additional Notes

Since this PR involves changes across multiple components related to string handling, I'd appreciate a thorough review to ensure there are no unintended side effects. If there's a better approach to solving the empty string issue, I'm open to suggestions.

Also, please note that the current main branch has an issue (#2211) affecting CrossLanguageTest, which this PR will also encounter. It might be beneficial to address #2211 first or at least be aware of it when reviewing this PR.
