### PR TITLE
fix(java): MemoryBuffer getRemainingBytes can return unexpected results on a slice

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -2447,7 +2447,7 @@ public final class MemoryBuffer {
    */
   public byte[] getRemainingBytes() {
     int length = size - readerIndex;
-    if (heapMemory != null && size == length) {
+    if (heapMemory != null && size == length && heapOffset == 0) {
       return heapMemory;
     } else {
       return getBytes(readerIndex, length);

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -195,6 +195,17 @@ public class MemoryBufferTest {
   }
 
   @Test
+  public void testSliceAndGetRemainingBytes() {
+    MemoryBuffer buf = MemoryBuffer.newHeapBuffer(16);
+    for (int i = 0; i < 16; i++) {
+      buf.writeByte(i);
+    }
+    byte[] sliceRemaining = buf.slice(4, 8).getRemainingBytes();
+    byte[] expected = buf.getBytes(4, 8);
+    assertEquals(sliceRemaining, expected);
+  }
+
+  @Test
   public void testEqualTo() {
     MemoryBuffer buf1 = MemoryUtils.buffer(16);
     MemoryBuffer buf2 = MemoryUtils.buffer(16);


### PR DESCRIPTION
## What does this PR do?

The implementation of MemoryBuffer.getRemainingBytes, if I am understanding correctly, should return only the remaining bytes. On a sliced buffer, it returns the shared bytes, which is different than the remaining bytes in the slice.
