### PR TITLE
chore(java): gitignore testng output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ benchmark/target
 **/target/**/**
 java/**/.code/
 java/**/dependency-reduced-pom.xml
+java/**/test-output
 **/pom.xml.versionsBackup
 **/.code/
 **/*.iml


### PR DESCRIPTION
## What does this PR do?

TestNG creates output files which are not ignored by `.gitignore`