### PR TITLE
feat(java): row encoder supports custom types and collections

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/type/CustomTypeRegistry.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/CustomTypeRegistry.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.type;
+
+import org.apache.fury.annotation.Internal;
+
+@Internal
+public interface CustomTypeRegistry {
+  CustomTypeRegistry EMPTY =
+      new CustomTypeRegistry() {
+        @Override
+        public boolean hasCodec(final Class<?> beanType, final Class<?> fieldType) {
+          return false;
+        }
+
+        @Override
+        public boolean canConstructCollection(
+            final Class<?> collectionType, final Class<?> elementType) {
+          return false;
+        }
+      };
+
+  boolean hasCodec(Class<?> beanType, Class<?> fieldType);
+
+  boolean canConstructCollection(Class<?> collectionType, Class<?> elementType);
+}

--- a/java/fury-core/src/main/java/org/apache/fury/type/TypeUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/TypeUtils.java
@@ -568,6 +568,10 @@ public class TypeUtils {
     return isBean(TypeRef.of(clz));
   }
 
+  public static boolean isBean(Type type, CustomTypeRegistry customTypes) {
+    return isBean(TypeRef.of(type), new LinkedHashSet<>(), customTypes);
+  }
+
   /**
    * Returns true if class is not array/iterable/map, and all fields is {@link
    * TypeUtils#isSupported(TypeRef)}. Bean class can't be a non-static inner class. Public static
@@ -577,7 +581,14 @@ public class TypeUtils {
     return isBean(typeRef, new LinkedHashSet<>());
   }
 
-  private static boolean isBean(TypeRef<?> typeRef, LinkedHashSet<TypeRef> walkedTypePath) {
+  private static boolean isBean(TypeRef<?> typeRef, LinkedHashSet<TypeRef<?>> walkedTypePath) {
+    return isBean(typeRef, walkedTypePath, CustomTypeRegistry.EMPTY);
+  }
+
+  private static boolean isBean(
+      TypeRef<?> typeRef,
+      LinkedHashSet<TypeRef<?>> walkedTypePath,
+      CustomTypeRegistry customTypes) {
     Class<?> cls = getRawType(typeRef);
     if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {
       return false;
@@ -589,7 +600,7 @@ public class TypeUtils {
       if (cls.getEnclosingClass() != null && !Modifier.isStatic(cls.getModifiers())) {
         return false;
       }
-      LinkedHashSet<TypeRef> newTypePath = new LinkedHashSet<>(walkedTypePath);
+      LinkedHashSet<TypeRef<?>> newTypePath = new LinkedHashSet<>(walkedTypePath);
       newTypePath.add(typeRef);
       if (cls == Object.class) {
         // return false for typeToken that point to un-specialized generic type.
@@ -602,6 +613,7 @@ public class TypeUtils {
               && !ITERABLE_TYPE.isSupertypeOf(typeRef)
               && !MAP_TYPE.isSupertypeOf(typeRef);
       if (maybe) {
+        Class<?> enclosingType = enclosingType(newTypePath);
         return Descriptor.getDescriptors(cls).stream()
             .allMatch(
                 d -> {
@@ -609,7 +621,9 @@ public class TypeUtils {
                   // do field modifiers and getter/setter validation here, not in getDescriptors.
                   // If Modifier.isFinal(d.getModifiers()), use reflection
                   // private field that doesn't have getter/setter will be handled by reflection.
-                  return isSupported(t, newTypePath) || isBean(t, newTypePath);
+                  return customTypes.hasCodec(enclosingType, t.getRawType())
+                      || isSupported(t, newTypePath, customTypes)
+                      || isBean(t, newTypePath, customTypes);
                 });
       } else {
         return false;
@@ -621,10 +635,13 @@ public class TypeUtils {
 
   /** Check if <code>typeToken</code> is supported by row-format. */
   public static boolean isSupported(TypeRef<?> typeRef) {
-    return isSupported(typeRef, new LinkedHashSet<>());
+    return isSupported(typeRef, new LinkedHashSet<>(), CustomTypeRegistry.EMPTY);
   }
 
-  private static boolean isSupported(TypeRef<?> typeRef, LinkedHashSet<TypeRef> walkedTypePath) {
+  private static boolean isSupported(
+      TypeRef<?> typeRef,
+      LinkedHashSet<TypeRef<?>> walkedTypePath,
+      CustomTypeRegistry customTypes) {
     Class<?> cls = getRawType(typeRef);
     if (!Modifier.isPublic(cls.getModifiers())) {
       return false;
@@ -639,6 +656,10 @@ public class TypeUtils {
     } else if (typeRef.isArray()) {
       return isSupported(Objects.requireNonNull(typeRef.getComponentType()));
     } else if (ITERABLE_TYPE.isSupertypeOf(typeRef)) {
+      TypeRef<?> elementType = getElementType(typeRef);
+      if (customTypes.canConstructCollection(typeRef.getRawType(), elementType.getRawType())) {
+        return true;
+      }
       boolean isSuperOfArrayList = cls.isAssignableFrom(ArrayList.class);
       boolean isSuperOfHashSet = cls.isAssignableFrom(HashSet.class);
       if ((!isSuperOfArrayList && !isSuperOfHashSet)
@@ -658,7 +679,7 @@ public class TypeUtils {
         throw new UnsupportedOperationException(
             "cyclic type is not supported. walkedTypePath: " + walkedTypePath);
       } else {
-        LinkedHashSet<TypeRef> newTypePath = new LinkedHashSet<>(walkedTypePath);
+        LinkedHashSet<TypeRef<?>> newTypePath = new LinkedHashSet<>(walkedTypePath);
         newTypePath.add(typeRef);
         return isBean(typeRef, newTypePath);
       }
@@ -673,13 +694,24 @@ public class TypeUtils {
    *     parameters recursively
    */
   public static LinkedHashSet<Class<?>> listBeansRecursiveInclusive(Class<?> beanClass) {
-    return listBeansRecursiveInclusive(beanClass, new LinkedHashSet<>());
+    return listBeansRecursiveInclusive(beanClass, CustomTypeRegistry.EMPTY);
+  }
+
+  public static LinkedHashSet<Class<?>> listBeansRecursiveInclusive(
+      Class<?> beanClass, CustomTypeRegistry customTypes) {
+    return listBeansRecursiveInclusive(beanClass, new LinkedHashSet<>(), customTypes);
   }
 
   private static LinkedHashSet<Class<?>> listBeansRecursiveInclusive(
-      Class<?> beanClass, LinkedHashSet<TypeRef<?>> walkedTypePath) {
+      Class<?> beanClass,
+      LinkedHashSet<TypeRef<?>> walkedTypePath,
+      CustomTypeRegistry customTypes) {
     LinkedHashSet<Class<?>> beans = new LinkedHashSet<>();
-    if (isBean(beanClass)) {
+    Class<?> enclosingType = enclosingType(walkedTypePath);
+    if (customTypes.hasCodec(enclosingType, beanClass)) {
+      return beans;
+    }
+    if (isBean(beanClass, customTypes)) {
       beans.add(beanClass);
     }
     LinkedHashSet<TypeRef<?>> typeRefs = new LinkedHashSet<>();
@@ -692,33 +724,34 @@ public class TypeUtils {
 
     for (TypeRef<?> typeToken : typeRefs) {
       Class<?> type = getRawType(typeToken);
-      if (isBean(type)) {
-        beans.add(type);
+      if (isBean(type, customTypes)) {
         if (walkedTypePath.contains(typeToken)) {
           throw new UnsupportedOperationException(
               "cyclic type is not supported. walkedTypePath: " + walkedTypePath);
         } else {
           LinkedHashSet<TypeRef<?>> newPath = new LinkedHashSet<>(walkedTypePath);
           newPath.add(typeToken);
-          beans.addAll(listBeansRecursiveInclusive(type, newPath));
+          beans.addAll(listBeansRecursiveInclusive(type, newPath, customTypes));
         }
       } else if (isCollection(type)) {
         TypeRef<?> elementType = getElementType(typeToken);
         LinkedHashSet<TypeRef<?>> newPath = new LinkedHashSet<>(walkedTypePath);
         newPath.add(elementType);
-        beans.addAll(listBeansRecursiveInclusive(elementType.getClass(), newPath));
+        beans.addAll(listBeansRecursiveInclusive(elementType.getClass(), newPath, customTypes));
       } else if (isMap(type)) {
         Tuple2<TypeRef<?>, TypeRef<?>> mapKeyValueType = getMapKeyValueType(typeToken);
         LinkedHashSet<TypeRef<?>> newPath = new LinkedHashSet<>(walkedTypePath);
         newPath.add(mapKeyValueType.f0);
         newPath.add(mapKeyValueType.f1);
-        beans.addAll(listBeansRecursiveInclusive(mapKeyValueType.f0.getRawType(), newPath));
-        beans.addAll(listBeansRecursiveInclusive(mapKeyValueType.f1.getRawType(), newPath));
+        beans.addAll(
+            listBeansRecursiveInclusive(mapKeyValueType.f0.getRawType(), newPath, customTypes));
+        beans.addAll(
+            listBeansRecursiveInclusive(mapKeyValueType.f1.getRawType(), newPath, customTypes));
       } else if (type.isArray()) {
         Class<?> arrayComponent = getArrayComponent(type);
         LinkedHashSet<TypeRef<?>> newPath = new LinkedHashSet<>(walkedTypePath);
         newPath.add(TypeRef.of(arrayComponent));
-        beans.addAll(listBeansRecursiveInclusive(arrayComponent, newPath));
+        beans.addAll(listBeansRecursiveInclusive(arrayComponent, newPath, customTypes));
       }
     }
     return beans;
@@ -737,7 +770,7 @@ public class TypeUtils {
   }
 
   /** Returns generic type arguments of <code>typeToken</code>. */
-  public static List<TypeRef<?>> getTypeArguments(TypeRef typeRef) {
+  public static List<TypeRef<?>> getTypeArguments(TypeRef<?> typeRef) {
     if (typeRef.getType() instanceof ParameterizedType) {
       ParameterizedType parameterizedType = (ParameterizedType) typeRef.getType();
       return Arrays.stream(parameterizedType.getActualTypeArguments())
@@ -752,7 +785,7 @@ public class TypeUtils {
    * Returns generic type arguments of <code>typeToken</code>, includes generic type arguments of
    * generic type arguments recursively.
    */
-  public static List<TypeRef<?>> getAllTypeArguments(TypeRef typeRef) {
+  public static List<TypeRef<?>> getAllTypeArguments(TypeRef<?> typeRef) {
     List<TypeRef<?>> types = getTypeArguments(typeRef);
     LinkedHashSet<TypeRef<?>> allTypeArguments = new LinkedHashSet<>(types);
     for (TypeRef<?> type : types) {
@@ -775,5 +808,13 @@ public class TypeUtils {
     } else {
       return pkg + "." + className;
     }
+  }
+
+  private static Class<?> enclosingType(LinkedHashSet<TypeRef<?>> newTypePath) {
+    Class<?> result = Object.class;
+    for (TypeRef<?> type : newTypePath) {
+      result = type.getRawType();
+    }
+    return result;
   }
 }

--- a/java/fury-format/README.md
+++ b/java/fury-format/README.md
@@ -11,3 +11,45 @@ Fury row format is heavily inspired by spark tungsten row format, but with chang
 - Support adding fields without breaking compatibility.
 
 The initial fury java row data structure implementation is modified from spark unsafe row/writer.
+
+It is possible to register custom type handling and collection factories for the row format -
+see Encoders.registerCustomCodec and Encoders.registerCustomCollectionFactory.
+
+A short example:
+
+```
+@Data
+public static class UuidType {
+  public UUID f1;
+  public UUID[] f2;
+  public SortedSet<UUID> f3;
+}
+
+static class UuidEncoder implements CustomCodec.MemoryBufferCodec<UUID> {
+  @Override
+  public MemoryBuffer encode(final UUID value) {
+    final MemoryBuffer result = MemoryBuffer.newHeapBuffer(16);
+    result.putInt64(0, value.getMostSignificantBits());
+    result.putInt64(8, value.getLeastSignificantBits());
+    return result;
+  }
+
+  @Override
+  public UUID decode(final MemoryBuffer value) {
+    return new UUID(value.readInt64(), value.readInt64());
+  }
+}
+
+static class SortedSetOfUuidDecoder implements CustomCollectionFactory<UUID, SortedSet<UUID>> {
+  @Override
+  public SortedSet<UUID> newCollection(final int size) {
+    return new TreeSet<>(UnsignedUuidComparator.INSTANCE);
+  }
+}
+
+Encoders.registerCustomCodec(UUID.class, new UuidEncoder());
+Encoders.registerCustomCollectionFactory(
+    SortedSet.class, UUID.class, new SortedSetOfUuidDecoder());
+
+RowEncoder<UuidType> encoder = Encoders.bean(UuidType.class);
+```

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/CustomCodec.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/CustomCodec.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.format.encoder;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.fury.format.row.binary.BinaryArray;
+import org.apache.fury.format.type.DataTypes;
+import org.apache.fury.memory.MemoryBuffer;
+
+public interface CustomCodec<T, E> {
+  Field getField(String fieldName);
+
+  Class<E> encodedType();
+
+  E encode(T value);
+
+  T decode(E value);
+
+  interface MemoryBufferCodec<T> extends CustomCodec<T, MemoryBuffer> {
+    @Override
+    default Class<MemoryBuffer> encodedType() {
+      return MemoryBuffer.class;
+    }
+
+    @Override
+    default Field getField(final String fieldName) {
+      return Field.nullable(fieldName, ArrowType.Binary.INSTANCE);
+    }
+  }
+
+  interface ByteArrayCodec<T> extends CustomCodec<T, byte[]> {
+    @Override
+    default Class<byte[]> encodedType() {
+      return byte[].class;
+    }
+
+    @Override
+    default Field getField(final String fieldName) {
+      return DataTypes.primitiveArrayField(fieldName, DataTypes.int8());
+    }
+  }
+
+  interface BinaryArrayCodec<T> extends CustomCodec<T, BinaryArray> {
+    @Override
+    default Class<BinaryArray> encodedType() {
+      return BinaryArray.class;
+    }
+
+    @Override
+    default Field getField(final String fieldName) {
+      return DataTypes.primitiveArrayField(fieldName, DataTypes.int8());
+    }
+  }
+}

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/CustomCollectionFactory.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/CustomCollectionFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.format.encoder;
+
+import java.util.Collection;
+
+public interface CustomCollectionFactory<E, C extends Collection<E>> {
+  C newCollection(int size);
+}

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/MapEncoderBuilder.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/MapEncoderBuilder.java
@@ -53,6 +53,7 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
   private static final String ROOT_VALUE_WRITER_NAME = "valueArrayWriter";
 
   private static final TypeRef<Field> ARROW_FIELD_TYPE = TypeRef.of(Field.class);
+  private static final Expression MAP_TYPE_EXPR = Expression.Literal.ofClass(Map.class);
   private final TypeRef<?> mapToken;
 
   public MapEncoderBuilder(Class<?> mapCls, Class<?> keyClass) {
@@ -180,7 +181,7 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
     expressions.add(
         new Expression.Invoke(keyArrayWriter, "writeDirectly", Expression.Literal.ofInt(-1)));
     Expression keySerializationExpr =
-        serializeForArrayByWriter(keySet, keyArrayWriter, keySetType, keyFieldExpr);
+        serializeForArrayByWriter(MAP_TYPE_EXPR, keySet, keyArrayWriter, keySetType, keyFieldExpr);
     Expression.Invoke keyArray =
         new Expression.Invoke(keyArrayWriter, "toArray", TypeRef.of(BinaryArray.class));
     expressions.add(map);
@@ -195,7 +196,7 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
 
     Expression.Invoke values = new Expression.Invoke(map, "values", valuesType);
     Expression valueSerializationExpr =
-        serializeForArrayByWriter(values, valArrayWriter, valuesType, valFieldExpr);
+        serializeForArrayByWriter(MAP_TYPE_EXPR, values, valArrayWriter, valuesType, valFieldExpr);
     Expression.Invoke valArray =
         new Expression.Invoke(valArrayWriter, "toArray", TypeRef.of(BinaryArray.class));
 
@@ -237,14 +238,14 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
     Expression keyJavaArray;
     Expression valueJavaArray;
     if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(keysType)) {
-      keyJavaArray = deserializeForCollection(keyArrayRef, keysType);
+      keyJavaArray = deserializeForCollection(MAP_TYPE_EXPR, keyArrayRef, keysType);
     } else {
-      keyJavaArray = deserializeForArray(keyArrayRef, keysType);
+      keyJavaArray = deserializeForArray(MAP_TYPE_EXPR, keyArrayRef, keysType);
     }
     if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(valuesType)) {
-      valueJavaArray = deserializeForCollection(valArrayRef, valuesType);
+      valueJavaArray = deserializeForCollection(MAP_TYPE_EXPR, valArrayRef, valuesType);
     } else {
-      valueJavaArray = deserializeForArray(valArrayRef, valuesType);
+      valueJavaArray = deserializeForArray(MAP_TYPE_EXPR, valArrayRef, valuesType);
     }
 
     Expression.ZipForEach put =

--- a/java/fury-format/src/main/java/org/apache/fury/format/row/binary/BinaryUtils.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/row/binary/BinaryUtils.java
@@ -26,7 +26,7 @@ import org.apache.fury.type.TypeUtils;
 /** Util class for building generated binary encoder. */
 @SuppressWarnings("UnstableApiUsage")
 public class BinaryUtils {
-  public static String getElemAccessMethodName(TypeRef type) {
+  public static String getElemAccessMethodName(TypeRef<?> type) {
     if (TypeUtils.PRIMITIVE_BYTE_TYPE.equals(type) || TypeUtils.BYTE_TYPE.equals(type)) {
       return "getByte";
     } else if (TypeUtils.PRIMITIVE_BOOLEAN_TYPE.equals(type)
@@ -50,7 +50,7 @@ public class BinaryUtils {
       return "getTimestamp";
     } else if (TypeUtils.STRING_TYPE.equals(type)) {
       return "getString";
-    } else if (type.isArray() || TypeUtils.ITERABLE_TYPE.isSupertypeOf(type)) {
+    } else if (isArray(type)) {
       // Since row-format serialize bytes as array data, instead of call `writer.write(int ordinal,
       // byte[] input)`,
       // we take BINARY_TYPE as byte[] array.
@@ -90,7 +90,7 @@ public class BinaryUtils {
       return TypeUtils.LONG_TYPE;
     } else if (TypeUtils.STRING_TYPE.equals(type)) {
       return TypeUtils.STRING_TYPE;
-    } else if (type.isArray() || TypeUtils.ITERABLE_TYPE.isSupertypeOf(type)) {
+    } else if (isArray(type)) {
       // take BINARY_TYPE as array
       return TypeRef.of(BinaryArray.class);
     } else if (TypeUtils.MAP_TYPE.isSupertypeOf(type)) {
@@ -102,5 +102,11 @@ public class BinaryUtils {
       // slice MemoryBuffer, then deserialize in EncodeExpressionBuilder.deserializeFor
       return TypeRef.of(MemoryBuffer.class);
     }
+  }
+
+  private static boolean isArray(TypeRef<?> type) {
+    return type.isArray()
+        || BinaryArray.class.equals(type.getRawType())
+        || TypeUtils.ITERABLE_TYPE.isSupertypeOf(type);
   }
 }

--- a/java/fury-format/src/main/java/org/apache/fury/format/type/CustomTypeEncoderRegistry.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/type/CustomTypeEncoderRegistry.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.format.type;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import org.apache.fury.annotation.Internal;
+import org.apache.fury.codegen.CodegenContext;
+import org.apache.fury.codegen.CompileUnit;
+import org.apache.fury.codegen.Expression;
+import org.apache.fury.codegen.Expression.Reference;
+import org.apache.fury.codegen.JaninoUtils;
+import org.apache.fury.format.encoder.CustomCodec;
+import org.apache.fury.format.encoder.CustomCollectionFactory;
+import org.apache.fury.reflect.TypeRef;
+import org.apache.fury.util.unsafe.DefineClass;
+
+/**
+ * Keep a registry of custom codecs and collection factories. In order to deliver peak performance,
+ * the configuration is generated into a class with static methods to avoid the overhead of virtual
+ * dispatch. The method signatures match the requested bean / field or collection / element types.
+ * Then, we dispatch to the user code via a {@code static final} field. This should allow the JIT to
+ * easily inline the calls.
+ */
+@Internal
+public class CustomTypeEncoderRegistry {
+  static final Map<CustomTypeRegistration, CustomCodec<?, ?>> REGISTRY = new HashMap<>();
+  static final Map<CustomTypeRegistration, CustomCollectionFactory<?, ?>> COLLECTION_REGISTRY =
+      new HashMap<>();
+  private static int generation = 0;
+  private static CustomTypeHandler generatedHandler = CustomTypeHandler.EMPTY;
+
+  static synchronized <T> void registerCustomCodec(
+      final CustomTypeRegistration registration, final CustomCodec<T, ?> encoder) {
+    REGISTRY.put(registration, encoder);
+    generatedHandler = null;
+  }
+
+  static synchronized void registerCustomCollection(
+      final Class<?> iterableType,
+      final Class<?> elementType,
+      final CustomCollectionFactory<?, ?> decoder) {
+    COLLECTION_REGISTRY.put(new CustomTypeRegistration(iterableType, elementType), decoder);
+    generatedHandler = null;
+  }
+
+  public static synchronized CustomTypeHandler customTypeHandler() {
+    if (generatedHandler != null) {
+      return generatedHandler;
+    }
+    generation++;
+    genCode();
+    return generatedHandler;
+  }
+
+  private static void genCode() {
+    final String pkg = CustomTypeEncoderRegistry.class.getPackage().getName();
+    final String className = "CustomTypeEncoderRegistry$Gen" + generation;
+    final CodegenContext ctx = new CodegenContext(pkg, new HashSet<>(), new LinkedHashSet<>());
+    ctx.setClassName(className);
+    ctx.implementsInterfaces(CustomTypeHandler.class.getName());
+
+    // Copy mutable state so the generated class is immutable
+    ctx.addField(
+        true,
+        true,
+        "java.util.Map<CustomTypeRegistration, CustomCodec<?, ?>>",
+        "REGISTRY",
+        new Expression.NewInstance(
+            TypeRef.of(HashMap.class),
+            Reference.fieldRef("CustomTypeEncoderRegistry.REGISTRY", TypeRef.of(Map.class))));
+    ctx.addField(
+        true,
+        true,
+        "java.util.Map<CustomTypeRegistration, CustomCollectionFactory<?, ?>>",
+        "COLLECTION_REGISTRY",
+        new Expression.NewInstance(
+            TypeRef.of(HashMap.class),
+            Reference.fieldRef(
+                "CustomTypeEncoderRegistry.COLLECTION_REGISTRY", TypeRef.of(Map.class))));
+    // Dynamic lookup, not used by generated row codec
+    ctx.addMethod(
+        "public",
+        "findCodec",
+        "return CustomTypeEncoderRegistry.findCodec(REGISTRY, beanType, fieldType);",
+        CustomCodec.class,
+        Class.class,
+        "beanType",
+        Class.class,
+        "fieldType");
+    ctx.addMethod(
+        "public",
+        "findCollectionFactory",
+        "return CustomTypeEncoderRegistry.findCollectionFactory(COLLECTION_REGISTRY, containerType, elementType);",
+        CustomCollectionFactory.class,
+        Class.class,
+        "containerType",
+        Class.class,
+        "elementType");
+    // Static dispatch table for custom codecs
+    REGISTRY.forEach(
+        new BiConsumer<CustomTypeRegistration, CustomCodec<?, ?>>() {
+          int codecCount = 0;
+
+          @Override
+          public void accept(final CustomTypeRegistration reg, final CustomCodec<?, ?> enc) {
+            codecCount++;
+            final String codecFieldName =
+                "CODEC_"
+                    + reg.getBeanType().getSimpleName()
+                    + "_"
+                    + reg.getFieldType().getSimpleName()
+                    + "_"
+                    + codecCount;
+            ctx.addStaticMethod(
+                "encode",
+                "return ("
+                    + ctx.type(enc.encodedType())
+                    + ")"
+                    + codecFieldName
+                    + ".encode(fieldValue);",
+                enc.encodedType(),
+                reg.getBeanType(),
+                "bean",
+                reg.getFieldType(),
+                "fieldValue");
+            ctx.addStaticMethod(
+                "decode",
+                "return ("
+                    + reg.getFieldType().getName()
+                    + ")"
+                    + codecFieldName
+                    + ".decode(encodedValue);",
+                reg.getFieldType(),
+                reg.getBeanType(),
+                "bean",
+                reg.getFieldType(),
+                "fieldNull",
+                enc.encodedType(),
+                "encodedValue");
+            ctx.addField(
+                true,
+                true,
+                CustomCodec.class.getName(),
+                codecFieldName,
+                Expression.Invoke.inlineInvoke(
+                    new Expression.Reference("CustomTypeEncoderRegistry"),
+                    "findCodec",
+                    TypeRef.of(CustomCodec.class),
+                    false,
+                    new Expression.Reference("REGISTRY", TypeRef.of(Map.class)),
+                    Expression.Literal.ofClass(reg.getBeanType()),
+                    Expression.Literal.ofClass(reg.getFieldType())));
+          }
+        });
+
+    // Static dispatch table for custom collection factories
+    COLLECTION_REGISTRY.forEach(
+        new BiConsumer<CustomTypeRegistration, CustomCollectionFactory<?, ?>>() {
+          int factoryCount = 0;
+
+          @Override
+          public void accept(
+              final CustomTypeRegistration reg, final CustomCollectionFactory<?, ?> dec) {
+            factoryCount++;
+            final String factoryFieldName =
+                "FACTORY_"
+                    + reg.getBeanType().getSimpleName()
+                    + "_"
+                    + reg.getFieldType().getSimpleName()
+                    + "_"
+                    + factoryCount;
+            ctx.addStaticMethod(
+                "newCollection",
+                "return ("
+                    + ctx.type(reg.getBeanType())
+                    + ")"
+                    + factoryFieldName
+                    + ".newCollection(numElements);",
+                reg.getBeanType(),
+                reg.getBeanType(),
+                "collectionNull",
+                reg.getFieldType(),
+                "elementNull",
+                int.class,
+                "numElements");
+            ctx.addField(
+                true,
+                true,
+                ctx.type(CustomCollectionFactory.class),
+                factoryFieldName,
+                Expression.Invoke.inlineInvoke(
+                    new Expression.Reference("CustomTypeEncoderRegistry"),
+                    "findCollectionFactory",
+                    TypeRef.of(CustomCollectionFactory.class),
+                    false,
+                    new Expression.Reference("COLLECTION_REGISTRY", TypeRef.of(Map.class)),
+                    Expression.Literal.ofClass(reg.getBeanType()),
+                    Expression.Literal.ofClass(reg.getFieldType())));
+          }
+        });
+
+    final CompileUnit compileUnit = new CompileUnit(pkg, className, ctx.genCode());
+    final Map<String, byte[]> classByteCodes =
+        JaninoUtils.toBytecode(CustomTypeEncoderRegistry.class.getClassLoader(), compileUnit);
+    final byte[] code = classByteCodes.values().iterator().next();
+    try {
+      generatedHandler =
+          (CustomTypeHandler)
+              DefineClass.defineClass(
+                      compileUnit.getQualifiedClassName(),
+                      CustomTypeEncoderRegistry.class,
+                      CustomTypeEncoderRegistry.class.getClassLoader(),
+                      CustomTypeEncoderRegistry.class.getProtectionDomain(),
+                      code)
+                  .getConstructor()
+                  .newInstance();
+    } catch (final Exception e) {
+      if (e instanceof RuntimeException) {
+        throw (RuntimeException) e;
+      } else {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  static CustomCodec<?, ?> findCodec(
+      final Map<CustomTypeRegistration, CustomCodec<?, ?>> registry,
+      final Class<?> beanType,
+      final Class<?> fieldType) {
+    CustomCodec<?, ?> result = registry.get(new CustomTypeRegistration(beanType, fieldType));
+    if (result == null) {
+      result = registry.get(new CustomTypeRegistration(Object.class, fieldType));
+    }
+    return result;
+  }
+
+  static CustomCollectionFactory<?, ?> findCollectionFactory(
+      final Map<CustomTypeRegistration, CustomCollectionFactory<?, ?>> registry,
+      final Class<?> containerType,
+      final Class<?> elementType) {
+    return registry.get(new CustomTypeRegistration(containerType, elementType));
+  }
+}

--- a/java/fury-format/src/main/java/org/apache/fury/format/type/CustomTypeHandler.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/type/CustomTypeHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.format.type;
+
+import org.apache.fury.annotation.Internal;
+import org.apache.fury.format.encoder.CustomCodec;
+import org.apache.fury.format.encoder.CustomCollectionFactory;
+import org.apache.fury.type.CustomTypeRegistry;
+
+@Internal
+public interface CustomTypeHandler extends CustomTypeRegistry {
+  static final CustomTypeHandler EMPTY =
+      new CustomTypeHandler() {
+        @Override
+        public <T> CustomCodec<T, ?> findCodec(final Class<?> beanType, final Class<T> fieldType) {
+          return null;
+        }
+
+        @Override
+        public CustomCollectionFactory<?, ?> findCollectionFactory(
+            final Class<?> collectionType, final Class<?> elementType) {
+          return null;
+        }
+      };
+
+  <T> CustomCodec<T, ?> findCodec(Class<?> beanType, Class<T> fieldType);
+
+  CustomCollectionFactory<?, ?> findCollectionFactory(
+      Class<?> collectionType, Class<?> elementType);
+
+  @Override
+  default boolean hasCodec(final Class<?> beanType, final Class<?> fieldType) {
+    return findCodec(beanType, fieldType) != null;
+  }
+
+  @Override
+  default boolean canConstructCollection(
+      final Class<?> collectionType, final Class<?> elementType) {
+    return findCollectionFactory(collectionType, elementType) != null;
+  }
+}

--- a/java/fury-format/src/main/java/org/apache/fury/format/type/CustomTypeRegistration.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/type/CustomTypeRegistration.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.format.type;
+
+import java.util.Objects;
+
+public class CustomTypeRegistration {
+  private final Class<?> beanType;
+  private final Class<?> fieldType;
+
+  public CustomTypeRegistration(final Class<?> beanType, final Class<?> fieldType) {
+    this.beanType = beanType;
+    this.fieldType = fieldType;
+  }
+
+  public Class<?> getBeanType() {
+    return beanType;
+  }
+
+  public Class<?> getFieldType() {
+    return fieldType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(beanType, fieldType);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    final CustomTypeRegistration other = (CustomTypeRegistration) obj;
+    return Objects.equals(beanType, other.beanType) && Objects.equals(fieldType, other.fieldType);
+  }
+
+  @Override
+  public String toString() {
+    return "CustomTypeRegistration [beanType=" + beanType + ", fieldType=" + fieldType + "]";
+  }
+}

--- a/java/fury-format/src/test/java/org/apache/fury/format/encoder/CustomCodecTest.java
+++ b/java/fury-format/src/test/java/org/apache/fury/format/encoder/CustomCodecTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.format.encoder;
+
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.UUID;
+import lombok.Data;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.fury.format.row.binary.BinaryArray;
+import org.apache.fury.format.row.binary.BinaryRow;
+import org.apache.fury.format.type.DataTypes;
+import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.memory.MemoryUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class CustomCodecTest {
+
+  static {
+    Encoders.registerCustomCodec(CustomType.class, ZoneId.class, new ZoneIdEncoder());
+    Encoders.registerCustomCodec(CustomByteBuf.class, new CustomByteBufEncoder());
+    Encoders.registerCustomCodec(CustomByteBuf2.class, new CustomByteBuf2Encoder());
+    Encoders.registerCustomCodec(CustomByteBuf3.class, new CustomByteBuf3Encoder());
+    Encoders.registerCustomCodec(UUID.class, new UuidEncoder());
+    Encoders.registerCustomCollectionFactory(
+        SortedSet.class, UUID.class, new SortedSetOfUuidDecoder());
+  }
+
+  @Data
+  public static class CustomType {
+    public ZoneId f1;
+    public CustomByteBuf f2;
+    public CustomByteBuf2 f3;
+    public CustomByteBuf3 f4;
+
+    public CustomType() {}
+  }
+
+  @Data
+  public static class CustomByteBuf {
+    final byte[] buf;
+
+    CustomByteBuf(final byte[] buf) {
+      this.buf = buf;
+    }
+  }
+
+  @Data
+  public static class CustomByteBuf2 {
+    final byte[] buf;
+
+    CustomByteBuf2(final byte[] buf) {
+      this.buf = buf;
+    }
+  }
+
+  @Data
+  public static class CustomByteBuf3 {
+    final byte[] buf;
+
+    CustomByteBuf3(final byte[] buf) {
+      this.buf = buf;
+    }
+  }
+
+  @Data
+  public static class UuidType {
+    public UUID f1;
+    public UUID[] f2;
+    public SortedSet<UUID> f3;
+
+    public UuidType() {}
+  }
+
+  @Test
+  public void testCustomTypes() {
+    final CustomType bean = new CustomType();
+    bean.f1 = ZoneId.of("America/Los_Angeles");
+    bean.f2 = new CustomByteBuf("f2 value".getBytes(StandardCharsets.UTF_8));
+    bean.f3 = new CustomByteBuf2("f3 value".getBytes(StandardCharsets.UTF_8));
+    bean.f4 = new CustomByteBuf3("f4 value".getBytes(StandardCharsets.UTF_8));
+    final RowEncoder<CustomType> encoder = Encoders.bean(CustomType.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final CustomType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean, bean);
+  }
+
+  @Test
+  public void testNullFields() {
+    final CustomType bean = new CustomType();
+    final RowEncoder<CustomType> encoder = Encoders.bean(CustomType.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final CustomType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean, bean);
+  }
+
+  @Test
+  public void testUuidFields() {
+    final UuidType bean = new UuidType();
+    bean.f1 = new UUID(1, 2);
+    bean.f2 = new UUID[] {new UUID(2, 3), new UUID(3, 4), new UUID(5, 6)};
+    bean.f3 = new TreeSet<>(Arrays.asList(new UUID(7, 8), new UUID(9, 10)));
+    final RowEncoder<UuidType> encoder = Encoders.bean(UuidType.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final UuidType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean, bean);
+    Assert.assertEquals(deserializedBean.f3.comparator(), UnsignedUuidComparator.INSTANCE);
+  }
+
+  static class ZoneIdEncoder implements CustomCodec<ZoneId, String> {
+    @Override
+    public Field getField(final String fieldName) {
+      return Field.nullable(fieldName, ArrowType.Utf8.INSTANCE);
+    }
+
+    @Override
+    public String encode(final ZoneId value) {
+      return Objects.toString(value, null);
+    }
+
+    @Override
+    public ZoneId decode(final String value) {
+      return ZoneId.of(value);
+    }
+
+    @Override
+    public Class<String> encodedType() {
+      return String.class;
+    }
+  }
+
+  static class CustomByteBufEncoder implements CustomCodec.MemoryBufferCodec<CustomByteBuf> {
+    @Override
+    public MemoryBuffer encode(final CustomByteBuf value) {
+      return MemoryBuffer.fromByteArray(value.buf);
+    }
+
+    @Override
+    public CustomByteBuf decode(final MemoryBuffer value) {
+      return new CustomByteBuf(value.getRemainingBytes());
+    }
+  }
+
+  static class CustomByteBuf2Encoder implements CustomCodec.ByteArrayCodec<CustomByteBuf2> {
+    @Override
+    public byte[] encode(final CustomByteBuf2 value) {
+      return value.buf;
+    }
+
+    @Override
+    public CustomByteBuf2 decode(final byte[] value) {
+      return new CustomByteBuf2(value);
+    }
+  }
+
+  static class CustomByteBuf3Encoder implements CustomCodec.BinaryArrayCodec<CustomByteBuf3> {
+    @Override
+    public Field getField(final String fieldName) {
+      return DataTypes.primitiveArrayField(fieldName, DataTypes.int8());
+    }
+
+    @Override
+    public Class<BinaryArray> encodedType() {
+      return BinaryArray.class;
+    }
+
+    @Override
+    public BinaryArray encode(final CustomByteBuf3 value) {
+      return BinaryArray.fromPrimitiveArray(value.buf);
+    }
+
+    @Override
+    public CustomByteBuf3 decode(final BinaryArray value) {
+      return new CustomByteBuf3(value.toByteArray());
+    }
+  }
+
+  static class UuidEncoder implements CustomCodec.MemoryBufferCodec<UUID> {
+    @Override
+    public MemoryBuffer encode(final UUID value) {
+      final MemoryBuffer result = MemoryBuffer.newHeapBuffer(16);
+      result.putInt64(0, value.getMostSignificantBits());
+      result.putInt64(8, value.getLeastSignificantBits());
+      return result;
+    }
+
+    @Override
+    public UUID decode(final MemoryBuffer value) {
+      return new UUID(value.readInt64(), value.readInt64());
+    }
+  }
+
+  static class SortedSetOfUuidDecoder implements CustomCollectionFactory<UUID, SortedSet<UUID>> {
+    @Override
+    public SortedSet<UUID> newCollection(final int size) {
+      return new TreeSet<>(UnsignedUuidComparator.INSTANCE);
+    }
+  }
+
+  private enum UnsignedUuidComparator implements Comparator<UUID> {
+    INSTANCE;
+
+    @Override
+    public int compare(final UUID o1, final UUID o2) {
+      final int cmpMsb =
+          Long.compareUnsigned(o1.getMostSignificantBits(), o2.getMostSignificantBits());
+      if (cmpMsb != 0) {
+        return cmpMsb;
+      }
+      return Long.compareUnsigned(o1.getLeastSignificantBits(), o2.getLeastSignificantBits());
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Extend Java Row Format to allow registering custom datatypes (e.g. UUID as Int128) and collection factories (e.g. `SortedSet<UUID>` as `new TreeSet<UUID>(customComparator)` )
Additionally supports arrays of custom types e.g. `UUID[]`

Since the type inference is in `fury-core` but I wanted to keep new features scoped to `fury-format`, I had to add a small plugin interface to core so that format can add types dynamically without affecting existing core behavior.

## Related issues

https://github.com/apache/fury/issues/2208

## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

The `Encoders` class has new `registerCustomCodec` and `registerCustomCollectionFactory` methods.
All custom types are written with the existing protocol as embedded memory buffers just like any other field, but with a custom byte representation, so there should be no wire compatibility concerns.

## Benchmark

There should be no change to performance in existing use cases. The code is carefully written to have no runtime impact if not used. Custom types are invoked via static methods or instance method on static final fields, which should be easily inlined by jit for minimum overhead.

Here is example generated code to help show this:
https://gist.github.com/stevenschlansker/ed7dae863e78d3c87e30bdea39fa8dea
