### PR TITLE
fix(C++): Fix reversed parameters and incorrect calls in string_util benchmark

### DIFF
--- a/cpp/fury/benchmark/benchmark_string_util.cc
+++ b/cpp/fury/benchmark/benchmark_string_util.cc
@@ -148,17 +148,16 @@ std::u16string generateUtf16(size_t length) {
   return result;
 }
 
-
 /*
- * Number of test strings to generate.
- * Each benchmark will run on `num_tests` samples.
+ *  Number of test strings to generate.
+ *  Each benchmark will run on `num_tests` samples.
  */
 const size_t num_tests = 1000;
 
 /*
- * Target length when generating individual strings.
- * For single-byte encodings (ASCII, Latin-1), this is exact.
- * For multibyte encodings (UTF-8, UTF-16), actual string size may vary slightly.
+ *  Target length when generating individual strings.
+ *  For single-byte encodings (ASCII, Latin-1), this is exact.
+ *  For multibyte encodings (UTF-8, UTF-16), actual string size may vary slightly.
  */
 const size_t string_length = 1000;
 
@@ -592,6 +591,7 @@ static void BM_Utf8ToUtf16_StandardLibrary(benchmark::State &state) {
     }
   }
 }
+
 BENCHMARK(BM_Utf8ToUtf16_StandardLibrary);
 
 // Benchmark function for Baseline UTF-8 to UTF-16 conversion

--- a/cpp/fury/benchmark/benchmark_string_util.cc
+++ b/cpp/fury/benchmark/benchmark_string_util.cc
@@ -34,7 +34,6 @@
  */
 
 // Generate random bytes (0x00 to 0xFF)
-
 std::mt19937 &getGenerator() {
   static thread_local std::mt19937 generator(std::random_device{}());
   return generator;

--- a/cpp/fury/benchmark/benchmark_string_util.cc
+++ b/cpp/fury/benchmark/benchmark_string_util.cc
@@ -148,10 +148,18 @@ std::u16string generateUtf16(size_t length) {
   return result;
 }
 
+
 /*
- *  TEST NUM
+ * Number of test strings to generate.
+ * Each benchmark will run on `num_tests` samples.
  */
 const size_t num_tests = 1000;
+
+/*
+ * Target length when generating individual strings.
+ * For single-byte encodings (ASCII, Latin-1), this is exact.
+ * For multibyte encodings (UTF-8, UTF-16), actual string size may vary slightly.
+ */
 const size_t string_length = 1000;
 
 /*

--- a/cpp/fury/benchmark/benchmark_string_util.cc
+++ b/cpp/fury/benchmark/benchmark_string_util.cc
@@ -34,15 +34,21 @@
  */
 
 // Generate random bytes (0x00 to 0xFF)
+
+std::mt19937 &getGenerator() {
+  static thread_local std::mt19937 generator(std::random_device{}());
+  return generator;
+}
+
 std::string generateRandom(size_t length) {
   std::string result;
   result.reserve(length);
 
-  std::mt19937 generator(std::random_device{}());
+  std::mt19937 &rng = getGenerator();
   std::uniform_int_distribution<unsigned short> distribution(0x00, 0xFF);
 
   for (size_t i = 0; i < length; ++i) {
-    result.push_back(static_cast<char>(distribution(generator)));
+    result.push_back(static_cast<char>(distribution(rng)));
   }
   return result;
 }
@@ -51,7 +57,7 @@ std::string generateRandom(size_t length) {
 std::string generateAscii(size_t length) {
   const char charset[] =
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  std::default_random_engine rng(std::random_device{}());
+  std::mt19937 &rng = getGenerator();
   std::uniform_int_distribution<> dist(0, sizeof(charset) - 2);
 
   std::string result;
@@ -67,11 +73,11 @@ std::u16string generateLatin1(size_t length) {
   std::u16string result;
   result.reserve(length);
 
-  std::mt19937 generator(std::random_device{}());
+  std::mt19937 &rng = getGenerator();
   std::uniform_int_distribution<uint16_t> distribution(0x00, 0xFF);
 
   for (size_t i = 0; i < length; ++i) {
-    result.push_back(static_cast<char16_t>(distribution(generator)));
+    result.push_back(static_cast<char16_t>(distribution(rng)));
   }
   return result;
 }
@@ -81,11 +87,11 @@ std::string generateUtf8(size_t length) {
   std::string result;
   result.reserve(length);
 
-  std::mt19937 generator(std::random_device{}());
+  std::mt19937 &rng = getGenerator();
   std::uniform_int_distribution<uint32_t> distribution(0, 0x10FFFF);
 
   while (result.size() < length) {
-    uint32_t code_point = distribution(generator);
+    uint32_t code_point = distribution(rng);
 
     // Skip surrogate pairs (0xD800 to 0xDFFF) and invalid Unicode code points
     if ((code_point >= 0xD800 && code_point <= 0xDFFF) ||
@@ -117,11 +123,11 @@ std::u16string generateUtf16(size_t length) {
   std::u16string result;
   result.reserve(length);
 
-  std::mt19937 generator(std::random_device{}());
+  std::mt19937 &rng = getGenerator();
   std::uniform_int_distribution<uint32_t> distribution(0, 0x10FFFF);
 
   while (result.size() < length) {
-    uint32_t code_point = distribution(generator);
+    uint32_t code_point = distribution(rng);
 
     // Skip surrogate pairs (0xD800 to 0xDFFF) and invalid Unicode code points
     if ((code_point >= 0xD800 && code_point <= 0xDFFF) ||
@@ -156,8 +162,8 @@ const size_t string_length = 1000;
 std::vector<std::string> generateAsciiString(size_t num_tests,
                                              size_t string_length) {
   std::vector<std::string> test_strings;
-  for (size_t i = 0; i < string_length; ++i) {
-    test_strings.push_back(generateUtf8(num_tests));
+  for (size_t i = 0; i < num_tests; ++i) {
+    test_strings.push_back(generateAscii(string_length));
   }
   return test_strings;
 }
@@ -182,8 +188,8 @@ const std::vector<std::u16string> test_latin1_strings =
 std::vector<std::u16string> generateUTF16String(size_t num_tests,
                                                 size_t string_length) {
   std::vector<std::u16string> test_strings;
-  for (size_t i = 0; i < string_length; ++i) {
-    test_strings.push_back(generateUtf16(num_tests));
+  for (size_t i = 0; i < num_tests; ++i) {
+    test_strings.push_back(generateUtf16(string_length));
   }
   return test_strings;
 }
@@ -195,8 +201,8 @@ const std::vector<std::u16string> test_utf16_strings =
 std::vector<std::string> generateUTF8String(size_t num_tests,
                                             size_t string_length) {
   std::vector<std::string> test_strings;
-  for (size_t i = 0; i < string_length; ++i) {
-    test_strings.push_back(generateUtf8(num_tests));
+  for (size_t i = 0; i < num_tests; ++i) {
+    test_strings.push_back(generateUtf8(string_length));
   }
   return test_strings;
 }
@@ -226,7 +232,7 @@ bool isAscii_SIMDUTF(const std::string &str) {
 // Benchmark function for Baseline ASCII check
 static void BM_IsAscii_BaseLine(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_ascii_strings) {
+    for (const std::string &str : test_ascii_strings) {
       bool result = isAscii_BaseLine(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -238,7 +244,7 @@ BENCHMARK(BM_IsAscii_BaseLine);
 // Benchmark function for SIMDUTF ASCII check
 static void BM_IsAscii_SIMDUTF(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_ascii_strings) {
+    for (const std::string &str : test_ascii_strings) {
       bool result = isAscii_SIMDUTF(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -250,7 +256,7 @@ BENCHMARK(BM_IsAscii_SIMDUTF);
 // Benchmark function for SIMD ASCII check
 static void BM_IsAscii_FURY(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_ascii_strings) {
+    for (const std::string &str : test_ascii_strings) {
       bool result = fury::isAscii(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -288,7 +294,7 @@ bool isLatin1_SIMDUTF(const std::u16string &str) {
 // Benchmark function for Baseline Latin-1 check
 static void BM_IsLatin1_BaseLine(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_latin1_strings) {
+    for (const std::u16string &str : test_latin1_strings) {
       bool result = isLatin1_BaseLine(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -300,7 +306,7 @@ BENCHMARK(BM_IsLatin1_BaseLine);
 // Benchmark function for Optimized Latin-1 check
 static void BM_IsLatin1_SIMDUTF(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_latin1_strings) {
+    for (const std::u16string &str : test_latin1_strings) {
       bool result = isLatin1_SIMDUTF(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -312,7 +318,7 @@ BENCHMARK(BM_IsLatin1_SIMDUTF);
 // Benchmark function for Optimized Latin-1 check
 static void BM_IsLatin1_FURY(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_latin1_strings) {
+    for (const std::u16string &str : test_latin1_strings) {
       bool result = fury::isLatin1(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -338,7 +344,7 @@ bool utf16HasSurrogatePairs_BaseLine(const std::u16string &str) {
 // Benchmark function for checking if a UTF-16 string contains surrogate pairs
 static void BM_Utf16HasSurrogatePairs_BaseLine(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf16_strings) {
+    for (const std::u16string &str : test_utf16_strings) {
       bool result = utf16HasSurrogatePairs_BaseLine(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -351,7 +357,7 @@ BENCHMARK(BM_Utf16HasSurrogatePairs_BaseLine);
 // with SIMD
 static void BM_Utf16HasSurrogatePairs_FURY(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf16_strings) {
+    for (const std::u16string &str : test_utf16_strings) {
       bool result = fury::utf16HasSurrogatePairs(str);
       benchmark::DoNotOptimize(result); // Prevent compiler optimization
     }
@@ -418,7 +424,7 @@ std::string utf16ToUtf8_SIMDUTF(const std::u16string &utf16,
 // Benchmark function for Standard Library UTF-16 to UTF-8 conversion
 static void BM_Utf16ToUtf8_StandardLibrary(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf16_strings) {
+    for (const std::u16string &str : test_utf16_strings) {
       std::string utf8 = utf16ToUtf8StandardLibrary(str);
       benchmark::DoNotOptimize(
           utf8); // Prevents the compiler from optimizing away unused variables
@@ -431,7 +437,7 @@ BENCHMARK(BM_Utf16ToUtf8_StandardLibrary);
 // Benchmark function for Baseline UTF-16 to UTF-8 conversion
 static void BM_Utf16ToUtf8_BaseLine(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf16_strings) {
+    for (const std::u16string &str : test_utf16_strings) {
       std::string utf8 = utf16ToUtf8BaseLine(str, true);
       benchmark::DoNotOptimize(
           utf8); // Prevents the compiler from optimizing away unused variables
@@ -444,7 +450,7 @@ BENCHMARK(BM_Utf16ToUtf8_BaseLine);
 // Benchmark function for SIMD-based UTF-16 to UTF-8 conversion
 static void BM_Utf16ToUtf8_SIMDUTF(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf16_strings) {
+    for (const std::u16string &str : test_utf16_strings) {
       std::string utf8 = utf16ToUtf8_SIMDUTF(str, true);
       benchmark::DoNotOptimize(
           utf8); // Prevents the compiler from optimizing away unused variables
@@ -457,7 +463,7 @@ BENCHMARK(BM_Utf16ToUtf8_SIMDUTF);
 // Benchmark function for SIMD-based UTF-16 to UTF-8 conversion
 static void BM_Utf16ToUtf8_FURY(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf16_strings) {
+    for (const std::u16string &str : test_utf16_strings) {
       std::string utf8 = fury::utf16ToUtf8(str, true);
       benchmark::DoNotOptimize(
           utf8); // Prevents the compiler from optimizing away unused variables
@@ -572,7 +578,7 @@ std::u16string utf8ToUtf16_SIMDUTF(const std::string &utf8,
 // Benchmark function for Standard Library UTF-8 to UTF-16 conversion
 static void BM_Utf8ToUtf16_StandardLibrary(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf8_strings) {
+    for (const std::string &str : test_utf8_strings) {
       std::u16string utf16 = utf8ToUtf16StandardLibrary(str);
       benchmark::DoNotOptimize(
           utf16); // Prevents the compiler from optimizing away unused variables
@@ -584,7 +590,7 @@ BENCHMARK(BM_Utf8ToUtf16_StandardLibrary);
 // Benchmark function for Baseline UTF-8 to UTF-16 conversion
 static void BM_Utf8ToUtf16_BaseLine(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf8_strings) {
+    for (const std::string &str : test_utf8_strings) {
       std::u16string utf16 = utf8ToUtf16BaseLine(str, true);
       benchmark::DoNotOptimize(
           utf16); // Prevents the compiler from optimizing away unused variables
@@ -597,7 +603,7 @@ BENCHMARK(BM_Utf8ToUtf16_BaseLine);
 // Benchmark function for SIMD-based UTF-8 to UTF-16 conversion
 static void BM_Utf8ToUtf16_SIMDUTF(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf8_strings) {
+    for (const std::string &str : test_utf8_strings) {
       std::u16string utf16 = utf8ToUtf16_SIMDUTF(str, true);
       benchmark::DoNotOptimize(
           utf16); // Prevents the compiler from optimizing away unused variables
@@ -610,7 +616,7 @@ BENCHMARK(BM_Utf8ToUtf16_SIMDUTF);
 // Benchmark function for SIMD-based UTF-8 to UTF-16 conversion
 static void BM_Utf8ToUtf16_FURY(benchmark::State &state) {
   for (auto _ : state) {
-    for (const auto &str : test_utf8_strings) {
+    for (const std::string &str : test_utf8_strings) {
       std::u16string utf16 = fury::utf8ToUtf16(str, true);
       benchmark::DoNotOptimize(
           utf16); // Prevents the compiler from optimizing away unused variables

--- a/cpp/fury/benchmark/benchmark_string_util.cc
+++ b/cpp/fury/benchmark/benchmark_string_util.cc
@@ -156,8 +156,8 @@ const size_t num_tests = 1000;
 
 /*
  *  Target length when generating individual strings.
- *  For single-byte encodings (ASCII, Latin-1), this is exact.
- *  For multibyte encodings (UTF-8, UTF-16), actual string size may vary slightly.
+ *  For ASCII, Latin-1, this is exact.
+ *  For UTF-8, UTF-16, actual string size may vary slightly.
  */
 const size_t string_length = 1000;
 


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
This PR fixes several minor issues and improves the implementation of string utility benchmarks:
- Corrected reversed function parameters.
- Fixed an incorrect function call.
- Replaced some usages of auto with explicit types for better readability and maintainability.
- Refactored random number generation by encapsulating std::mt19937 in a thread-local helper function.

One part of the original code used default random generation methods, which could result in uneven value distributions and non-deterministic behavior across platforms. To improve randomness quality and thread-safety, I replaced it with a `thread_local` encapsulated `std::mt19937` generator. This ensures better reproducibility and consistency during benchmarking.

After these changes, the code compiles and runs correctly. Benchmark results are stable and as expected. (See image below.)

<img width="842" alt="Screenshot 2025-05-19 at 17 24 58" src="https://github.com/user-attachments/assets/ddd329c4-ba14-4c9d-9fb1-ee4584c188b5" />


<!-- Describe the purpose of this PR. -->


## Related issues
- #2245


<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [x] Does this PR introduce any public API change?
- [x] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
