### PR TITLE
feat(java): fury row encoder now supports implementing interfaces with simple value type

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/annotation/FuryField.java
+++ b/java/fury-core/src/main/java/org/apache/fury/annotation/FuryField.java
@@ -25,7 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.METHOD})
 public @interface FuryField {
 
   /** Whether field is nullable, default false. */

--- a/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
@@ -96,7 +96,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
                       .getClassDef(beanClass, true)
                       .getDescriptors(classResolver, beanClass));
     } else {
-      descriptors = fury.getClassResolver().getAllDescriptorsMap(beanClass, true).values();
+      descriptors = fury.getClassResolver().getFieldDescriptors(beanClass, true);
     }
     DescriptorGrouper grouper = classResolver.createDescriptorGrouper(descriptors, false);
     descriptors = grouper.getSortedDescriptors();

--- a/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
+++ b/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
@@ -140,6 +140,7 @@ public class CodegenContext {
   String pkg;
   LinkedHashSet<String> imports = new LinkedHashSet<>();
   String className;
+  String classModifiers = "public final";
   String[] superClasses;
   String[] interfaces;
   List<FieldInfo> fields = new ArrayList<>();
@@ -416,6 +417,15 @@ public class CodegenContext {
   }
 
   /**
+   * Set class modifiers. Default is {@code public final}.
+   *
+   * @param classModifiers the new class modifiers
+   */
+  public void setClassModifiers(String classModifiers) {
+    this.classModifiers = classModifiers;
+  }
+
+  /**
    * Set super classes.
    *
    * @param superClasses super classes
@@ -626,7 +636,7 @@ public class CodegenContext {
       codeBuilder.append('\n');
     }
 
-    codeBuilder.append(String.format("public final class %s ", className));
+    codeBuilder.append(String.format("%s class %s ", classModifiers, className));
     if (superClasses != null) {
       codeBuilder.append(String.format("extends %s ", String.join(", ", superClasses)));
     }

--- a/java/fury-core/src/main/java/org/apache/fury/meta/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/ClassDef.java
@@ -30,6 +30,7 @@ import java.io.ObjectStreamClass;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -240,9 +241,9 @@ public class ClassDef implements Serializable {
    */
   public List<Descriptor> getDescriptors(ClassResolver resolver, Class<?> cls) {
     if (descriptors == null) {
-      SortedMap<Field, Descriptor> allDescriptorsMap = resolver.getAllDescriptorsMap(cls, true);
+      SortedMap<Member, Descriptor> allDescriptorsMap = resolver.getAllDescriptorsMap(cls, true);
       Map<String, Descriptor> descriptorsMap = new HashMap<>();
-      for (Map.Entry<Field, Descriptor> e : allDescriptorsMap.entrySet()) {
+      for (Map.Entry<Member, Descriptor> e : allDescriptorsMap.entrySet()) {
         if (descriptorsMap.put(
                 e.getKey().getDeclaringClass().getName() + "." + e.getKey().getName(), e.getValue())
             != null) {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/ClassDefEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/ClassDefEncoder.java
@@ -59,7 +59,7 @@ class ClassDefEncoder {
     DescriptorGrouper descriptorGrouper =
         fury.getClassResolver()
             .createDescriptorGrouper(
-                fury.getClassResolver().getAllDescriptorsMap(cls, resolveParent).values(),
+                fury.getClassResolver().getFieldDescriptors(cls, resolveParent),
                 false,
                 Function.identity());
     List<Field> fields = new ArrayList<>();

--- a/java/fury-core/src/main/java/org/apache/fury/meta/TypeDefEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/TypeDefEncoder.java
@@ -55,7 +55,7 @@ class TypeDefEncoder {
     DescriptorGrouper descriptorGrouper =
         fury.getClassResolver()
             .createDescriptorGrouper(
-                fury.getClassResolver().getAllDescriptorsMap(type, true).values(),
+                fury.getClassResolver().getFieldDescriptors(type, true),
                 false,
                 Function.identity());
     List<Field> fields =

--- a/java/fury-core/src/main/java/org/apache/fury/reflect/TypeRef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/reflect/TypeRef.java
@@ -167,6 +167,10 @@ public class TypeRef<T> {
     return type instanceof Class && ((Class<?>) type).isPrimitive();
   }
 
+  public boolean isInterface() {
+    return getRawType().isInterface();
+  }
+
   /**
    * Returns true if this type is known to be an array type, such as {@code int[]}, {@code T[]},
    * {@code <? extends Map<String, Integer>[]>} etc.

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -38,6 +38,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.lang.reflect.Member;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -262,7 +263,7 @@ public class ClassResolver implements TypeResolver {
     // Tuple2<Class, Class>: Tuple2<From Class, To Class>
     private final Map<Tuple2<Class<?>, Class<?>>, ClassInfo> transformedClassInfo = new HashMap<>();
     // TODO(chaokunyang) Better to  use soft reference, see ObjectStreamClass.
-    private final ConcurrentHashMap<Tuple2<Class<?>, Boolean>, SortedMap<Field, Descriptor>>
+    private final ConcurrentHashMap<Tuple2<Class<?>, Boolean>, SortedMap<Member, Descriptor>>
         descriptorsCache = new ConcurrentHashMap<>();
     private ClassChecker classChecker = (classResolver, className) -> true;
     private GenericType objectGenericType;
@@ -873,6 +874,7 @@ public class ClassResolver implements TypeResolver {
   }
 
   /** Get or create serializer for <code>cls</code>. */
+  @Override
   @SuppressWarnings("unchecked")
   public <T> Serializer<T> getSerializer(Class<T> cls) {
     Preconditions.checkNotNull(cls);
@@ -1187,8 +1189,20 @@ public class ClassResolver implements TypeResolver {
     return fieldResolver;
   }
 
+  public List<Descriptor> getFieldDescriptors(Class<?> clz, boolean searchParent) {
+    SortedMap<Member, Descriptor> allDescriptors = getAllDescriptorsMap(clz, searchParent);
+    List<Descriptor> result = new ArrayList<>(allDescriptors.size());
+    allDescriptors.forEach(
+        (member, descriptor) -> {
+          if (member instanceof Field) {
+            result.add(descriptor);
+          }
+        });
+    return result;
+  }
+
   // thread safe
-  public SortedMap<Field, Descriptor> getAllDescriptorsMap(Class<?> clz, boolean searchParent) {
+  public SortedMap<Member, Descriptor> getAllDescriptorsMap(Class<?> clz, boolean searchParent) {
     // when jit thread query this, it is already built by serialization main thread.
     return extRegistry.descriptorsCache.computeIfAbsent(
         Tuple2.of(clz, searchParent), t -> Descriptor.getAllDescriptorsMap(clz, searchParent));
@@ -1198,6 +1212,7 @@ public class ClassResolver implements TypeResolver {
    * Whether to track reference for this type. If false, reference tracing of subclasses may be
    * ignored too.
    */
+  @Override
   public boolean needToWriteRef(TypeRef<?> typeRef) {
     Object extInfo = typeRef.getExtInfo();
     if (extInfo instanceof TypeExtMeta) {
@@ -1239,6 +1254,7 @@ public class ClassResolver implements TypeResolver {
   }
 
   /** Get classinfo by cache, update cache if miss. */
+  @Override
   public ClassInfo getClassInfo(Class<?> cls, ClassInfoHolder classInfoHolder) {
     ClassInfo classInfo = classInfoHolder.classInfo;
     if (classInfo.getCls() != cls) {
@@ -1439,6 +1455,7 @@ public class ClassResolver implements TypeResolver {
   // }
 
   /** Write classname for java serialization. */
+  @Override
   public void writeClassInfo(MemoryBuffer buffer, ClassInfo classInfo) {
     if (metaContextShareEnabled) {
       // FIXME(chaokunyang) Register class but not register serializer can't be used with
@@ -1835,6 +1852,7 @@ public class ClassResolver implements TypeResolver {
   }
 
   /** Read class info, update classInfoHolder if cache not hit. */
+  @Override
   @CodegenInvoke
   public ClassInfo readClassInfo(MemoryBuffer buffer, ClassInfoHolder classInfoHolder) {
     if (metaContextShareEnabled) {
@@ -1986,6 +2004,7 @@ public class ClassResolver implements TypeResolver {
 
   public void resetWrite() {}
 
+  @Override
   public GenericType buildGenericType(TypeRef<?> typeRef) {
     return GenericType.build(
         typeRef,
@@ -1998,6 +2017,7 @@ public class ClassResolver implements TypeResolver {
         });
   }
 
+  @Override
   public GenericType buildGenericType(Type type) {
     GenericType genericType = extRegistry.genericTypes.get(type);
     if (genericType != null) {
@@ -2030,10 +2050,12 @@ public class ClassResolver implements TypeResolver {
   }
 
   // Invoked by fury JIT.
+  @Override
   public ClassInfo nilClassInfo() {
     return new ClassInfo(this, null, null, NO_CLASS_ID, NOT_SUPPORT_XLANG);
   }
 
+  @Override
   public ClassInfoHolder nilClassInfoHolder() {
     return new ClassInfoHolder(nilClassInfo());
   }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
@@ -98,7 +98,7 @@ public final class ObjectSerializer<T> extends AbstractObjectSerializer<T> {
       ClassDef classDef = classResolver.getClassDef(cls, resolveParent);
       descriptors = classDef.getDescriptors(classResolver, cls);
     } else {
-      descriptors = fury.getClassResolver().getAllDescriptorsMap(cls, resolveParent).values();
+      descriptors = fury.getClassResolver().getFieldDescriptors(cls, resolveParent);
     }
     DescriptorGrouper descriptorGrouper = classResolver.createDescriptorGrouper(descriptors, false);
     descriptors = descriptorGrouper.getSortedDescriptors();

--- a/java/fury-core/src/main/java/org/apache/fury/type/TypeResolutionContext.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/TypeResolutionContext.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.type;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.apache.fury.annotation.Internal;
+import org.apache.fury.reflect.TypeRef;
+
+@Internal
+public class TypeResolutionContext {
+  private final CustomTypeRegistry customTypeRegistry;
+  private final LinkedHashSet<TypeRef<?>> walkedTypePath;
+  private final Set<Class<?>> synthesizedBeanTypes;
+
+  public TypeResolutionContext(CustomTypeRegistry customTypeRegistry) {
+    this.customTypeRegistry = customTypeRegistry;
+    walkedTypePath = new LinkedHashSet<>();
+    synthesizedBeanTypes = Collections.emptySet();
+  }
+
+  public TypeResolutionContext(
+      CustomTypeRegistry customTypeRegistry,
+      LinkedHashSet<TypeRef<?>> walkedTypePath,
+      Set<Class<?>> synthesizedBeanTypes) {
+    this.customTypeRegistry = customTypeRegistry;
+    this.walkedTypePath = walkedTypePath;
+    this.synthesizedBeanTypes = synthesizedBeanTypes;
+  }
+
+  public CustomTypeRegistry getCustomTypeRegistry() {
+    return customTypeRegistry;
+  }
+
+  public LinkedHashSet<TypeRef<?>> getWalkedTypePath() {
+    return walkedTypePath;
+  }
+
+  public Set<Class<?>> getSynthesizedBeanTypes() {
+    return synthesizedBeanTypes;
+  }
+
+  public TypeRef<?> getEnclosingType() {
+    TypeRef<?> result = TypeRef.of(Object.class);
+    for (TypeRef<?> type : walkedTypePath) { // .getLast()
+      result = type;
+    }
+    return result;
+  }
+
+  public TypeResolutionContext appendTypePath(TypeRef<?>... typeRef) {
+    LinkedHashSet<TypeRef<?>> newWalkedTypePath = new LinkedHashSet<>(walkedTypePath);
+    newWalkedTypePath.addAll(Arrays.asList(typeRef));
+    return new TypeResolutionContext(customTypeRegistry, newWalkedTypePath, synthesizedBeanTypes);
+  }
+
+  public TypeResolutionContext appendTypePath(Class<?> clz) {
+    return appendTypePath(TypeRef.of(clz));
+  }
+
+  public TypeResolutionContext withSynthesizedBeanType(Class<?> clz) {
+    Set<Class<?>> newSynthesizedBeanTypes = new HashSet<>(synthesizedBeanTypes);
+    newSynthesizedBeanTypes.add(clz);
+    return new TypeResolutionContext(customTypeRegistry, walkedTypePath, newSynthesizedBeanTypes);
+  }
+
+  public boolean isSynthesizedBeanType(Class<?> cls) {
+    return synthesizedBeanTypes.contains(cls);
+  }
+
+  public void checkNoCycle(Class<?> clz) {
+    checkNoCycle(TypeRef.of(clz));
+  }
+
+  public void checkNoCycle(TypeRef<?> typeRef) {
+    if (walkedTypePath.contains(typeRef)
+        || walkedTypePath.contains(TypeRef.of(typeRef.getRawType()))) {
+      throw new UnsupportedOperationException(
+          "cyclic type is not supported. walkedTypePath: "
+              + walkedTypePath
+              + " seen type: "
+              + typeRef);
+    }
+  }
+}

--- a/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
@@ -467,7 +467,7 @@ public class CrossLanguageTest extends FuryTestBase {
         ObjectSerializer.class.getDeclaredMethod("computeStructHash", Fury.class, Collection.class);
     method.setAccessible(true);
     Collection<Descriptor> descriptors =
-        fury.getClassResolver().getAllDescriptorsMap(ComplexObject1.class, true).values();
+        fury.getClassResolver().getFieldDescriptors(ComplexObject1.class, true);
     descriptors =
         fury.getClassResolver().createDescriptorGrouper(descriptors, false).getSortedDescriptors();
     Integer hash = (Integer) method.invoke(serializer, fury, descriptors);

--- a/java/fury-format/README.md
+++ b/java/fury-format/README.md
@@ -13,16 +13,16 @@ Fury row format is heavily inspired by spark tungsten row format, but with chang
 The initial fury java row data structure implementation is modified from spark unsafe row/writer.
 
 It is possible to register custom type handling and collection factories for the row format -
-see Encoders.registerCustomCodec and Encoders.registerCustomCollectionFactory.
+see Encoders.registerCustomCodec and Encoders.registerCustomCollectionFactory. For an interface,
+Fury can synthesize a simple value implementation, such as the UuidType below.
 
 A short example:
 
 ```
-@Data
-public static class UuidType {
-  public UUID f1;
-  public UUID[] f2;
-  public SortedSet<UUID> f3;
+public interface UuidType {
+  UUID f1();
+  UUID[] f2();
+  SortedSet<UUID> f3();
 }
 
 static class UuidEncoder implements CustomCodec.MemoryBufferCodec<UUID> {

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/ArrayDataForEach.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/ArrayDataForEach.java
@@ -31,7 +31,9 @@ import org.apache.fury.codegen.Expression.AbstractExpression;
 import org.apache.fury.format.row.binary.BinaryArray;
 import org.apache.fury.format.row.binary.BinaryUtils;
 import org.apache.fury.format.type.CustomTypeEncoderRegistry;
+import org.apache.fury.format.type.CustomTypeHandler;
 import org.apache.fury.reflect.TypeRef;
+import org.apache.fury.type.TypeResolutionContext;
 import org.apache.fury.type.TypeUtils;
 import org.apache.fury.util.Preconditions;
 import org.apache.fury.util.StringUtils;
@@ -85,8 +87,13 @@ public class ArrayDataForEach extends AbstractExpression {
     } else {
       accessType = TypeRef.of(customEncoder.encodedType());
     }
-    this.accessMethod = BinaryUtils.getElemAccessMethodName(accessType);
-    this.elemType = BinaryUtils.getElemReturnType(accessType);
+    CustomTypeHandler customTypeHandler = CustomTypeEncoderRegistry.customTypeHandler();
+    TypeResolutionContext ctx = new TypeResolutionContext(customTypeHandler);
+    if (inputArrayData.type().getRawType().isInterface() && elemType.getRawType().isInterface()) {
+      ctx = ctx.withSynthesizedBeanType(elemType.getRawType());
+    }
+    this.accessMethod = BinaryUtils.getElemAccessMethodName(accessType, ctx);
+    this.elemType = BinaryUtils.getElemReturnType(accessType, ctx);
     this.notNullAction = notNullAction;
     this.nullAction = nullAction;
   }

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/ArrayEncoderBuilder.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/ArrayEncoderBuilder.java
@@ -48,7 +48,6 @@ public class ArrayEncoderBuilder extends BaseBinaryEncoderBuilder {
 
   private static final TypeRef<Field> ARROW_FIELD_TYPE = TypeRef.of(Field.class);
   private final TypeRef<?> arrayToken;
-  private final Expression emptyArrayInstance;
 
   public ArrayEncoderBuilder(Class<?> arrayCls, Class<?> beanClass) {
     this(TypeRef.of(arrayCls), TypeRef.of(beanClass));
@@ -79,7 +78,6 @@ public class ArrayEncoderBuilder extends BaseBinaryEncoderBuilder {
                 Expression.Literal.ofClass(beanType.getRawType()),
                 Expression.Literal.ofInt(0)),
             TypeRef.of(Array.newInstance(beanType.getRawType(), 0).getClass())));
-    emptyArrayInstance = new Expression.Reference(ROOT_EMPTY_ARRAY_NAME);
   }
 
   @Override
@@ -148,7 +146,7 @@ public class ArrayEncoderBuilder extends BaseBinaryEncoderBuilder {
 
     Expression.Reference fieldExpr = new Expression.Reference(FIELD_NAME, ARROW_FIELD_TYPE, false);
     Expression listExpression =
-        serializeForArrayByWriter(emptyArrayInstance, array, arrayWriter, arrayToken, fieldExpr);
+        serializeForArrayByWriter(array, arrayWriter, arrayToken, fieldExpr);
 
     expressions.add(listExpression);
 
@@ -183,8 +181,7 @@ public class ArrayEncoderBuilder extends BaseBinaryEncoderBuilder {
             arrayData,
             elemType,
             (i, value) ->
-                new Expression.Invoke(
-                    collection, "add", deserializeFor(emptyArrayInstance, value, elemType)),
+                new Expression.Invoke(collection, "add", deserializeFor(value, elemType, typeCtx)),
             i -> new Expression.Invoke(collection, "add", ExpressionUtils.nullValue(elemType)));
     return new Expression.ListExpression(collection, addElemsOp, collection);
   }

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/BaseBinaryEncoderBuilder.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/BaseBinaryEncoderBuilder.java
@@ -67,6 +67,7 @@ import org.apache.fury.format.type.DataTypes;
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.reflect.ReflectionUtils;
 import org.apache.fury.reflect.TypeRef;
+import org.apache.fury.type.TypeResolutionContext;
 import org.apache.fury.type.TypeUtils;
 import org.apache.fury.util.DateTimeUtils;
 import org.apache.fury.util.Preconditions;
@@ -95,6 +96,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
   protected final Map<TypeRef<?>, Reference> rowWriterMap = new HashMap<>();
   protected final CustomTypeHandler customTypeHandler =
       CustomTypeEncoderRegistry.customTypeHandler();
+  protected final TypeResolutionContext typeCtx;
 
   public BaseBinaryEncoderBuilder(CodegenContext context, Class<?> beanClass) {
     this(context, TypeRef.of(beanClass));
@@ -107,6 +109,12 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
     ctx.addImport(BinaryRow.class.getPackage().getName() + ".*");
     ctx.addImport(BinaryWriter.class.getPackage().getName() + ".*");
     ctx.addImport(Schema.class.getPackage().getName() + ".*");
+    TypeResolutionContext typeCtx = new TypeResolutionContext(customTypeHandler);
+    typeCtx.appendTypePath(beanClass);
+    if (beanClass.isInterface()) {
+      typeCtx = typeCtx.withSynthesizedBeanType(beanClass);
+    }
+    this.typeCtx = typeCtx;
   }
 
   public String codecClassName(Class<?> beanClass) {
@@ -140,7 +148,6 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
    * writer</code>
    */
   protected Expression serializeFor(
-      Expression bean,
       Expression ordinal,
       Expression inputObject,
       Expression writer,
@@ -157,10 +164,10 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
               "rewrittenValue",
               rewrittenType,
               true,
-              bean,
+              new Expression.Null(beanType, true),
               inputObject);
       Expression doSerialize =
-          serializeFor(bean, ordinal, newInputObject, writer, rewrittenType, arrowField);
+          serializeFor(ordinal, newInputObject, writer, rewrittenType, arrowField);
       return new If(
           ExpressionUtils.eqNull(inputObject),
           new Invoke(writer, "setNullAt", ordinal),
@@ -224,7 +231,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
       // but don't setOffsetAndSize for array.
       Invoke offset =
           new Invoke(writer, "writerIndex", "writerIndex", TypeUtils.PRIMITIVE_INT_TYPE);
-      Expression serializeArray = serializeForArray(bean, inputObject, writer, typeRef, arrowField);
+      Expression serializeArray = serializeForArray(inputObject, writer, typeRef, arrowField);
       Arithmetic size =
           ExpressionUtils.subtract(
               new Invoke(writer, "writerIndex", "writerIndex", TypeUtils.PRIMITIVE_INT_TYPE),
@@ -237,8 +244,8 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
           new Invoke(writer, "setNullAt", ordinal),
           expression);
     } else if (TypeUtils.MAP_TYPE.isSupertypeOf(typeRef)) {
-      return serializeForMap(bean, ordinal, writer, inputObject, typeRef, arrowField);
-    } else if (TypeUtils.isBean(rawType)) {
+      return serializeForMap(ordinal, writer, inputObject, typeRef, arrowField);
+    } else if (TypeUtils.isBean(rawType, createElementTypeContext(typeRef))) {
       return serializeForBean(ordinal, writer, inputObject, typeRef, arrowField);
     } else if (rawType == BinaryArray.class) {
       Invoke writeExp =
@@ -270,21 +277,13 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
   }
 
   protected Expression serializeForArray(
-      Expression bean,
-      Expression inputObject,
-      Expression writer,
-      TypeRef<?> typeRef,
-      Expression arrowField) {
+      Expression inputObject, Expression writer, TypeRef<?> typeRef, Expression arrowField) {
     Reference arrayWriter = getOrCreateArrayWriter(typeRef, arrowField, writer);
-    return serializeForArrayByWriter(bean, inputObject, arrayWriter, typeRef, arrowField);
+    return serializeForArrayByWriter(inputObject, arrayWriter, typeRef, arrowField);
   }
 
   protected Expression serializeForArrayByWriter(
-      Expression bean,
-      Expression inputObject,
-      Expression arrayWriter,
-      TypeRef<?> typeRef,
-      Expression arrowField) {
+      Expression inputObject, Expression arrayWriter, TypeRef<?> typeRef, Expression arrowField) {
     StaticInvoke arrayElementField =
         new StaticInvoke(
             DataTypes.class, "arrayElementField", "elemField", ARROW_FIELD_TYPE, false, arrowField);
@@ -301,7 +300,6 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
                 inputObject,
                 (i, value) ->
                     serializeFor(
-                        bean,
                         i,
                         value,
                         arrayWriter,
@@ -318,12 +316,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
               listFromIterable,
               (i, value) ->
                   serializeFor(
-                      bean,
-                      i,
-                      value,
-                      arrayWriter,
-                      TypeUtils.getElementType(typeRef),
-                      arrayElementField));
+                      i, value, arrayWriter, TypeUtils.getElementType(typeRef), arrayElementField));
       return new ListExpression(reset, forEach, arrayWriter);
     } else { // collection
       Invoke size = new Invoke(inputObject, "size", TypeUtils.PRIMITIVE_INT_TYPE);
@@ -333,12 +326,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
               inputObject,
               (i, value) ->
                   serializeFor(
-                      bean,
-                      i,
-                      value,
-                      arrayWriter,
-                      TypeUtils.getElementType(typeRef),
-                      arrayElementField));
+                      i, value, arrayWriter, TypeUtils.getElementType(typeRef), arrayElementField));
       return new ListExpression(reset, forEach, arrayWriter);
     }
   }
@@ -362,7 +350,6 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
    * row/array using given <code>writer</code>.
    */
   protected Expression serializeForMap(
-      Expression bean,
       Expression ordinal,
       Expression writer,
       Expression inputObject,
@@ -398,8 +385,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
     expressions.add(offset, preserve);
 
     Invoke keySet = new Invoke(inputObject, "keySet", keySetType);
-    Expression keySerializationExpr =
-        serializeForArray(bean, keySet, writer, keySetType, keyArrayField);
+    Expression keySerializationExpr = serializeForArray(keySet, writer, keySetType, keyArrayField);
     expressions.add(keySet, keySerializationExpr);
 
     expressions.add(
@@ -411,7 +397,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
 
     Invoke values = new Invoke(inputObject, "values", valuesType);
     Expression valueSerializationExpr =
-        serializeForArray(bean, values, writer, valuesType, valueArrayField);
+        serializeForArray(values, writer, valuesType, valueArrayField);
     expressions.add(values, valueSerializationExpr);
 
     Arithmetic size =
@@ -524,7 +510,8 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
    * Returns an expression that deserialize <code>value</code> as a java object of type <code>
    * typeToken</code>.
    */
-  protected Expression deserializeFor(Expression bean, Expression value, TypeRef<?> typeRef) {
+  protected Expression deserializeFor(
+      Expression value, TypeRef<?> typeRef, TypeResolutionContext ctx) {
     Class<?> rawType = getRawType(typeRef);
     CustomCodec<?, ?> customHandler = customTypeHandler.findCodec(beanType.getRawType(), rawType);
     if (customHandler != null) {
@@ -543,7 +530,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
               "decodedValue",
               typeRef,
               true,
-              bean,
+              new Expression.Null(beanType, true),
               new Expression.Null(typeRef, true),
               inputValue);
       if (rawRewrittenType == MemoryBuffer.class) {
@@ -553,7 +540,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
       } else if (rawRewrittenType == byte[].class) {
         return newValue;
       }
-      return deserializeFor(bean, newValue, rewrittenType);
+      return deserializeFor(newValue, rewrittenType, ctx);
     } else if (TypeUtils.isPrimitive(rawType) || TypeUtils.isBoxed(rawType)) {
       return value;
     } else if (rawType == BigDecimal.class) {
@@ -576,12 +563,12 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
     } else if (rawType.isEnum()) {
       return ExpressionUtils.valueOf(typeRef, value);
     } else if (rawType.isArray()) {
-      return deserializeForArray(bean, value, typeRef);
+      return deserializeForArray(value, typeRef);
     } else if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(typeRef)) {
-      return deserializeForCollection(bean, value, typeRef);
+      return deserializeForCollection(value, typeRef);
     } else if (TypeUtils.MAP_TYPE.isSupertypeOf(typeRef)) {
-      return deserializeForMap(bean, value, typeRef);
-    } else if (TypeUtils.isBean(rawType)) {
+      return deserializeForMap(value, typeRef);
+    } else if (TypeUtils.isBean(rawType, ctx)) {
       return deserializeForBean(value, typeRef);
     } else {
       return deserializeForObject(value, typeRef);
@@ -602,7 +589,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
   }
 
   /** Returns an expression that deserialize <code>mapData</code> as a java map. */
-  protected Expression deserializeForMap(Expression bean, Expression mapData, TypeRef<?> typeRef) {
+  protected Expression deserializeForMap(Expression mapData, TypeRef<?> typeRef) {
     Expression javaMap = newMap(typeRef);
     @SuppressWarnings("unchecked")
     TypeRef<?> supertype = ((TypeRef<? extends Map<?, ?>>) typeRef).getSupertype(Map.class);
@@ -614,14 +601,14 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
     Expression keyJavaArray;
     Expression valueJavaArray;
     if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(keysType)) {
-      keyJavaArray = deserializeForCollection(bean, keyArray, keysType);
+      keyJavaArray = deserializeForCollection(keyArray, keysType);
     } else {
-      keyJavaArray = deserializeForArray(bean, keyArray, keysType);
+      keyJavaArray = deserializeForArray(keyArray, keysType);
     }
     if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(valuesType)) {
-      valueJavaArray = deserializeForCollection(bean, valueArray, valuesType);
+      valueJavaArray = deserializeForCollection(valueArray, valuesType);
     } else {
-      valueJavaArray = deserializeForArray(bean, valueArray, valuesType);
+      valueJavaArray = deserializeForArray(valueArray, valuesType);
     }
 
     ZipForEach put =
@@ -634,8 +621,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
   }
 
   /** Returns an expression that deserialize <code>arrayData</code> as a java collection. */
-  protected Expression deserializeForCollection(
-      Expression bean, Expression arrayData, TypeRef<?> typeRef) {
+  protected Expression deserializeForCollection(Expression arrayData, TypeRef<?> typeRef) {
     Expression collection = newCollection(arrayData, typeRef);
     try {
       TypeRef<?> elemType = TypeUtils.getElementType(typeRef);
@@ -643,7 +629,11 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
           new ArrayDataForEach(
               arrayData,
               elemType,
-              (i, value) -> new Invoke(collection, "add", deserializeFor(bean, value, elemType)),
+              (i, value) ->
+                  new Invoke(
+                      collection,
+                      "add",
+                      deserializeFor(value, elemType, createElementTypeContext(elemType))),
               i -> new Invoke(collection, "add", ExpressionUtils.nullValue(elemType)));
       return new ListExpression(collection, addElemsOp, collection);
     } catch (Exception e) {
@@ -712,7 +702,6 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
    * <code>rootJavaArray</code>.
    */
   protected Expression deserializeForMultiDimensionArray(
-      Expression bean,
       Expression arrayData,
       Expression rootJavaArray,
       int numDimensions,
@@ -729,8 +718,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
             Expression[] newIndexes = Arrays.copyOf(indexes, indexes.length + 1);
             newIndexes[indexes.length] = i;
             Expression elemArr =
-                deserializeForArray(
-                    bean, value, Objects.requireNonNull(typeRef.getComponentType()));
+                deserializeForArray(value, Objects.requireNonNull(typeRef.getComponentType()));
             return new AssignArrayElem(rootJavaArray, elemArr, newIndexes);
           });
     } else {
@@ -741,7 +729,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
             Expression[] newIndexes = Arrays.copyOf(indexes, indexes.length + 1);
             newIndexes[indexes.length] = i;
             return deserializeForMultiDimensionArray(
-                bean, value, rootJavaArray, numDimensions - 1, elemType, newIndexes);
+                value, rootJavaArray, numDimensions - 1, elemType, newIndexes);
           });
     }
   }
@@ -750,8 +738,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
    * Return an expression that deserialize <code>arrayData</code>. If array is multi-array, forward
    * to {@link BaseBinaryEncoderBuilder#deserializeForMultiDimensionArray}
    */
-  protected Expression deserializeForArray(
-      Expression bean, Expression arrayData, TypeRef<?> typeRef) {
+  protected Expression deserializeForArray(Expression arrayData, TypeRef<?> typeRef) {
     int numDimensions = TypeUtils.getArrayDimensions(typeRef);
     if (numDimensions > 1) {
       // If some dimension's elements is all null, we take outer-most array as null,
@@ -770,7 +757,7 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
       Expression rootJavaMultiDimArray = new NewArray(innerElemClass, numDimensions, dimensions);
       Expression op =
           deserializeForMultiDimensionArray(
-              bean, arrayData, rootJavaMultiDimArray, numDimensions, typeRef, new Expression[0]);
+              arrayData, rootJavaMultiDimArray, numDimensions, typeRef, new Expression[0]);
       // although the value maybe null, we don't use this info, so we set nullability to false.
       return new If(
           ExpressionUtils.notNull(dimensions),
@@ -802,7 +789,8 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
                 arrayData,
                 elemType,
                 (i, value) -> {
-                  Expression elemValue = deserializeFor(bean, value, elemType);
+                  Expression elemValue =
+                      deserializeFor(value, elemType, createElementTypeContext(elemType));
                   return new AssignArrayElem(javaArray, elemValue, i);
                 });
         // add javaArray at last as expression value
@@ -817,5 +805,15 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
    */
   protected Expression deserializeForObject(Expression value, TypeRef<?> typeRef) {
     return new Invoke(furyRef, "deserialize", typeRef, value);
+  }
+
+  protected TypeResolutionContext createElementTypeContext(TypeRef<?> elemType) {
+    TypeResolutionContext newTypeCtx;
+    if (elemType.isInterface() && beanClass.isInterface()) {
+      newTypeCtx = typeCtx.withSynthesizedBeanType(elemType.getRawType());
+    } else {
+      newTypeCtx = typeCtx;
+    }
+    return newTypeCtx;
   }
 }

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/MapEncoderBuilder.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/MapEncoderBuilder.java
@@ -53,7 +53,6 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
   private static final String ROOT_VALUE_WRITER_NAME = "valueArrayWriter";
 
   private static final TypeRef<Field> ARROW_FIELD_TYPE = TypeRef.of(Field.class);
-  private static final Expression MAP_TYPE_EXPR = Expression.Literal.ofClass(Map.class);
   private final TypeRef<?> mapToken;
 
   public MapEncoderBuilder(Class<?> mapCls, Class<?> keyClass) {
@@ -181,7 +180,7 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
     expressions.add(
         new Expression.Invoke(keyArrayWriter, "writeDirectly", Expression.Literal.ofInt(-1)));
     Expression keySerializationExpr =
-        serializeForArrayByWriter(MAP_TYPE_EXPR, keySet, keyArrayWriter, keySetType, keyFieldExpr);
+        serializeForArrayByWriter(keySet, keyArrayWriter, keySetType, keyFieldExpr);
     Expression.Invoke keyArray =
         new Expression.Invoke(keyArrayWriter, "toArray", TypeRef.of(BinaryArray.class));
     expressions.add(map);
@@ -196,7 +195,7 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
 
     Expression.Invoke values = new Expression.Invoke(map, "values", valuesType);
     Expression valueSerializationExpr =
-        serializeForArrayByWriter(MAP_TYPE_EXPR, values, valArrayWriter, valuesType, valFieldExpr);
+        serializeForArrayByWriter(values, valArrayWriter, valuesType, valFieldExpr);
     Expression.Invoke valArray =
         new Expression.Invoke(valArrayWriter, "toArray", TypeRef.of(BinaryArray.class));
 
@@ -213,6 +212,7 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
    * Returns an expression that deserialize <code>row</code> as a java bean of type {@link
    * MapEncoderBuilder#mapToken}.
    */
+  @Override
   public Expression buildDecodeExpression() {
     Expression.ListExpression expressions = new Expression.ListExpression();
     Expression map = newMap(mapToken);
@@ -238,14 +238,14 @@ public class MapEncoderBuilder extends BaseBinaryEncoderBuilder {
     Expression keyJavaArray;
     Expression valueJavaArray;
     if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(keysType)) {
-      keyJavaArray = deserializeForCollection(MAP_TYPE_EXPR, keyArrayRef, keysType);
+      keyJavaArray = deserializeForCollection(keyArrayRef, keysType);
     } else {
-      keyJavaArray = deserializeForArray(MAP_TYPE_EXPR, keyArrayRef, keysType);
+      keyJavaArray = deserializeForArray(keyArrayRef, keysType);
     }
     if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(valuesType)) {
-      valueJavaArray = deserializeForCollection(MAP_TYPE_EXPR, valArrayRef, valuesType);
+      valueJavaArray = deserializeForCollection(valArrayRef, valuesType);
     } else {
-      valueJavaArray = deserializeForArray(MAP_TYPE_EXPR, valArrayRef, valuesType);
+      valueJavaArray = deserializeForArray(valArrayRef, valuesType);
     }
 
     Expression.ZipForEach put =

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/RowEncoderBuilder.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/RowEncoderBuilder.java
@@ -48,6 +48,7 @@ import org.apache.fury.logging.Logger;
 import org.apache.fury.logging.LoggerFactory;
 import org.apache.fury.reflect.TypeRef;
 import org.apache.fury.type.Descriptor;
+import org.apache.fury.type.TypeResolutionContext;
 import org.apache.fury.type.TypeUtils;
 import org.apache.fury.util.GraalvmSupport;
 import org.apache.fury.util.Preconditions;
@@ -61,10 +62,13 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
   static final String ROOT_ROW_NAME = "row";
   static final String ROOT_ROW_WRITER_NAME = "rowWriter";
 
+  private final String className;
   private final SortedMap<String, Descriptor> descriptorsMap;
   private final Schema schema;
   protected static final String BEAN_CLASS_NAME = "beanClass";
   protected Reference beanClassRef = new Reference(BEAN_CLASS_NAME, CLASS_TYPE);
+  private final CodegenContext generatedBeanImpl;
+  private final String generatedBeanImplName;
 
   public RowEncoderBuilder(Class<?> beanClass) {
     this(TypeRef.of(beanClass));
@@ -72,7 +76,9 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
 
   public RowEncoderBuilder(TypeRef<?> beanType) {
     super(new CodegenContext(), beanType);
-    Preconditions.checkArgument(TypeUtils.isBean(beanType.getType(), customTypeHandler));
+    Preconditions.checkArgument(
+        beanClass.isInterface() || TypeUtils.isBean(beanType.getType(), customTypeHandler));
+    className = codecClassName(beanClass);
     this.schema = TypeInference.inferSchema(getRawType(beanType));
     this.descriptorsMap = Descriptor.getDescriptorsMap(beanClass);
     ctx.reserveName(ROOT_ROW_WRITER_NAME);
@@ -86,12 +92,19 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
       // non-public class is not accessible in other class.
       clsExpr =
           new Expression.StaticInvoke(
-              Class.class, "forName", CLASS_TYPE, false, Literal.ofClass(beanClass));
+              Class.class, "forName", CLASS_TYPE, false, Literal.ofString(ctx.type(beanClass)));
     }
     ctx.addField(Class.class, "beanClass", clsExpr);
     ctx.addImports(Field.class, Schema.class);
     ctx.addImports(Row.class, ArrayData.class, MapData.class);
     ctx.addImports(BinaryRow.class, BinaryArray.class, BinaryMap.class);
+    if (beanClass.isInterface()) {
+      generatedBeanImplName = beanClass.getSimpleName() + "GeneratedImpl";
+      generatedBeanImpl = buildImplClass();
+    } else {
+      generatedBeanImplName = null;
+      generatedBeanImpl = null;
+    }
   }
 
   @Override
@@ -102,7 +115,6 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
   @Override
   public String genCode() {
     ctx.setPackage(CodeGenerator.getPackage(beanClass));
-    String className = codecClassName(beanClass);
     ctx.setClassName(className);
     // don't addImport(beanClass), because user class may name collide.
     // janino don't support generics, so GeneratedCodec has no generics
@@ -141,6 +153,14 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
 
     long startTime = System.nanoTime();
     String code = ctx.genCode();
+    // It would be nice if Expression let us write inner classes
+    if (generatedBeanImpl != null) {
+      int insertPoint = code.lastIndexOf('}');
+      code =
+          code.substring(0, insertPoint)
+              + generatedBeanImpl.genCode()
+              + code.substring(insertPoint);
+    }
     long durationMs = (System.nanoTime() - startTime) / 1000;
     LOG.info("Generate codec for class {} take {} us", beanClass, durationMs);
     return code;
@@ -169,7 +189,7 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
       Expression.StaticInvoke field =
           new Expression.StaticInvoke(
               DataTypes.class, "fieldOfSchema", ARROW_FIELD_TYPE, false, schemaExpr, ordinal);
-      Expression fieldExpr = serializeFor(bean, ordinal, fieldValue, writer, fieldType, field);
+      Expression fieldExpr = serializeFor(ordinal, fieldValue, writer, fieldType, field);
       expressions.add(fieldExpr);
     }
     expressions.add(
@@ -185,6 +205,13 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
   @Override
   public Expression buildDecodeExpression() {
     Reference row = new Reference(ROOT_ROW_NAME, binaryRowTypeToken, false);
+
+    addDecoderMethods();
+
+    if (generatedBeanImpl != null) {
+      return new Expression.Return(
+          new Expression.Reference("new " + generatedBeanImplName + "(row)"));
+    }
     Expression bean = newBean();
 
     int numFields = schema.getFields().size();
@@ -197,16 +224,42 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
       TypeRef<?> fieldType = d.getTypeRef();
       Expression.Invoke isNullAt =
           new Expression.Invoke(row, "isNullAt", TypeUtils.PRIMITIVE_BOOLEAN_TYPE, ordinal);
-      CustomCodec<?, ?> customEncoder =
-          customTypeHandler.findCodec(beanClass, fieldType.getRawType());
+      Expression value =
+          new Expression.Variable(
+              "decoded" + i, new Expression.Reference("decode" + i + "(row)", fieldType));
+      Expression setActionExpr = setFieldValue(bean, d, value);
+      Expression action = new Expression.If(ExpressionUtils.not(isNullAt), setActionExpr);
+      expressions.add(action);
+    }
+
+    expressions.add(new Expression.Return(bean));
+    return expressions;
+  }
+
+  private void addDecoderMethods() {
+    Reference row = new Reference(ROOT_ROW_NAME, binaryRowTypeToken, false);
+    int numFields = schema.getFields().size();
+    for (int i = 0; i < numFields; i++) {
+      Literal ordinal = Literal.ofInt(i);
+      Descriptor d = getDescriptorByFieldName(schema.getFields().get(i).getName());
+      TypeRef<?> fieldType = d.getTypeRef();
+      Class<?> rawFieldType = fieldType.getRawType();
+      TypeResolutionContext fieldCtx;
+      if (beanClass.isInterface() && rawFieldType.isInterface()) {
+        fieldCtx = typeCtx.withSynthesizedBeanType(rawFieldType);
+      } else {
+        fieldCtx = typeCtx;
+      }
+      CustomCodec<?, ?> customEncoder = customTypeHandler.findCodec(beanClass, rawFieldType);
       TypeRef<?> columnAccessType;
       if (customEncoder == null) {
         columnAccessType = fieldType;
       } else {
         columnAccessType = TypeRef.of(customEncoder.encodedType());
       }
-      String columnAccessMethodName = BinaryUtils.getElemAccessMethodName(columnAccessType);
-      TypeRef<?> colType = BinaryUtils.getElemReturnType(columnAccessType);
+      String columnAccessMethodName =
+          BinaryUtils.getElemAccessMethodName(columnAccessType, fieldCtx);
+      TypeRef<?> colType = BinaryUtils.getElemReturnType(columnAccessType, fieldCtx);
       Expression.Invoke columnValue =
           new Expression.Invoke(
               row,
@@ -215,14 +268,64 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
               colType,
               false,
               ordinal);
-      Expression value = deserializeFor(bean, columnValue, fieldType);
-      Expression setActionExpr = setFieldValue(bean, d, value);
-      Expression action = new Expression.If(ExpressionUtils.not(isNullAt), setActionExpr);
-      expressions.add(action);
+      final Expression value =
+          new Expression.Return(deserializeFor(columnValue, fieldType, fieldCtx));
+      ctx.addMethod(
+          "decode" + i,
+          value.doGenCode(ctx).code(),
+          fieldType.getRawType(),
+          BinaryRow.class,
+          ROOT_ROW_NAME);
+    }
+  }
+
+  private CodegenContext buildImplClass() {
+    Reference row = new Reference(ROOT_ROW_NAME, binaryRowTypeToken, false);
+    CodegenContext implClass = new CodegenContext();
+    implClass.setClassModifiers("final");
+    implClass.setClassName(generatedBeanImplName);
+    implClass.implementsInterfaces(implClass.type(beanClass));
+    implClass.addField(true, implClass.type(BinaryRow.class), "row", null);
+    implClass.addConstructor("this.row = row;", BinaryRow.class, "row");
+
+    int numFields = schema.getFields().size();
+    for (int i = 0; i < numFields; i++) {
+      Literal ordinal = Literal.ofInt(i);
+      Descriptor d = getDescriptorByFieldName(schema.getFields().get(i).getName());
+      TypeRef<?> fieldType = d.getTypeRef();
+
+      Expression.Reference decodeValue =
+          new Expression.Reference("decode" + i + "(row)", fieldType);
+      Expression getterImpl;
+      if (fieldType.isPrimitive()) {
+        getterImpl = new Expression.Return(decodeValue);
+      } else {
+        String fieldName = "f" + i + "_" + d.getName();
+        implClass.addField(fieldType.getRawType(), fieldName);
+
+        Expression fieldRef = new Expression.Reference(fieldName, fieldType, true);
+        Expression storeValue =
+            new Expression.SetField(new Expression.Reference("this"), fieldName, decodeValue);
+        Expression loadIfFieldIsNull =
+            new Expression.If(new Expression.IsNull(fieldRef), storeValue);
+        Expression assigner;
+
+        if (d.isNullable()) {
+          Expression isNotNullAt =
+              new Expression.Not(
+                  new Expression.Invoke(
+                      row, "isNullAt", TypeUtils.PRIMITIVE_BOOLEAN_TYPE, ordinal));
+          assigner = new Expression.If(isNotNullAt, loadIfFieldIsNull);
+        } else {
+          assigner = loadIfFieldIsNull;
+        }
+        getterImpl = new Expression.ListExpression(assigner, new Expression.Return(fieldRef));
+      }
+      implClass.addMethod(
+          d.getName(), getterImpl.genCode(implClass).code(), fieldType.getRawType());
     }
 
-    expressions.add(new Expression.Return(bean));
-    return expressions;
+    return implClass;
   }
 
   private Descriptor getDescriptorByFieldName(String fieldName) {

--- a/java/fury-format/src/main/java/org/apache/fury/format/row/binary/BinaryUtils.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/row/binary/BinaryUtils.java
@@ -21,12 +21,13 @@ package org.apache.fury.format.row.binary;
 
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.reflect.TypeRef;
+import org.apache.fury.type.TypeResolutionContext;
 import org.apache.fury.type.TypeUtils;
 
 /** Util class for building generated binary encoder. */
 @SuppressWarnings("UnstableApiUsage")
 public class BinaryUtils {
-  public static String getElemAccessMethodName(TypeRef<?> type) {
+  public static String getElemAccessMethodName(TypeRef<?> type, TypeResolutionContext ctx) {
     if (TypeUtils.PRIMITIVE_BYTE_TYPE.equals(type) || TypeUtils.BYTE_TYPE.equals(type)) {
       return "getByte";
     } else if (TypeUtils.PRIMITIVE_BOOLEAN_TYPE.equals(type)
@@ -57,7 +58,7 @@ public class BinaryUtils {
       return "getArray";
     } else if (TypeUtils.MAP_TYPE.isSupertypeOf(type)) {
       return "getMap";
-    } else if (TypeUtils.isBean(type)) {
+    } else if (TypeUtils.isBean(type, ctx)) {
       return "getStruct";
     } else {
       // take unknown type as OBJECT_TYPE, return as sliced MemoryBuffer
@@ -66,7 +67,7 @@ public class BinaryUtils {
     }
   }
 
-  public static TypeRef<?> getElemReturnType(TypeRef<?> type) {
+  public static TypeRef<?> getElemReturnType(TypeRef<?> type, TypeResolutionContext ctx) {
     if (TypeUtils.PRIMITIVE_BYTE_TYPE.equals(type) || TypeUtils.BYTE_TYPE.equals(type)) {
       return TypeUtils.PRIMITIVE_BYTE_TYPE;
     } else if (TypeUtils.PRIMITIVE_BOOLEAN_TYPE.equals(type)
@@ -95,7 +96,7 @@ public class BinaryUtils {
       return TypeRef.of(BinaryArray.class);
     } else if (TypeUtils.MAP_TYPE.isSupertypeOf(type)) {
       return TypeRef.of(BinaryMap.class);
-    } else if (TypeUtils.isBean(type)) {
+    } else if (TypeUtils.isBean(type, ctx)) {
       return TypeRef.of(BinaryRow.class);
     } else {
       // take unknown type as OBJECT_TYPE, return as sliced MemoryBuffer

--- a/java/fury-format/src/main/java/org/apache/fury/format/type/TypeInference.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/type/TypeInference.java
@@ -24,7 +24,6 @@ import static org.apache.fury.type.TypeUtils.getRawType;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -42,6 +41,7 @@ import org.apache.fury.format.encoder.CustomCodec;
 import org.apache.fury.format.encoder.CustomCollectionFactory;
 import org.apache.fury.reflect.TypeRef;
 import org.apache.fury.type.Descriptor;
+import org.apache.fury.type.TypeResolutionContext;
 import org.apache.fury.type.TypeUtils;
 import org.apache.fury.util.DecimalUtils;
 import org.apache.fury.util.Preconditions;
@@ -120,13 +120,18 @@ public class TypeInference {
   }
 
   private static Field inferField(TypeRef<?> arrayTypeRef, TypeRef<?> typeRef) {
-    LinkedHashSet<Class<?>> seenTypeSet = new LinkedHashSet<>();
+    TypeResolutionContext ctx =
+        new TypeResolutionContext(CustomTypeEncoderRegistry.customTypeHandler());
+    Class<?> clz = getRawType(typeRef);
+    if (clz.isInterface()) {
+      ctx = ctx.withSynthesizedBeanType(clz);
+    }
     String name = "";
     if (arrayTypeRef != null) {
-      Field f = inferField(DataTypes.ARRAY_ITEM_NAME, typeRef, seenTypeSet);
+      Field f = inferField(DataTypes.ARRAY_ITEM_NAME, typeRef, ctx);
       return DataTypes.arrayField(name, f);
     } else {
-      return inferField("", typeRef, seenTypeSet);
+      return inferField("", typeRef, ctx);
     }
   }
 
@@ -136,19 +141,11 @@ public class TypeInference {
    *
    * @return DataType of a typeToken
    */
-  private static Field inferField(
-      String name, TypeRef<?> typeRef, LinkedHashSet<Class<?>> seenTypeSet) {
-    return inferField(name, typeRef, seenTypeSet, CustomTypeEncoderRegistry.customTypeHandler());
-  }
-
-  private static Field inferField(
-      String name,
-      TypeRef<?> typeRef,
-      LinkedHashSet<Class<?>> seenTypeSet,
-      CustomTypeHandler customTypes) {
+  private static Field inferField(String name, TypeRef<?> typeRef, TypeResolutionContext ctx) {
     Class<?> rawType = getRawType(typeRef);
-    Class<?> enclosingType = enclosingType(seenTypeSet);
-    CustomCodec<?, ?> customEncoder = customTypes.findCodec(enclosingType, rawType);
+    Class<?> enclosingType = ctx.getEnclosingType().getRawType();
+    CustomCodec<?, ?> customEncoder =
+        ((CustomTypeHandler) ctx.getCustomTypeRegistry()).findCodec(enclosingType, rawType);
     if (customEncoder != null) {
       return customEncoder.getField(name);
     } else if (rawType == boolean.class) {
@@ -207,53 +204,44 @@ public class TypeInference {
     } else if (rawType.isArray()) { // array
       Field f =
           inferField(
-              DataTypes.ARRAY_ITEM_NAME,
-              Objects.requireNonNull(typeRef.getComponentType()),
-              seenTypeSet,
-              customTypes);
+              DataTypes.ARRAY_ITEM_NAME, Objects.requireNonNull(typeRef.getComponentType()), ctx);
       return DataTypes.arrayField(name, f);
     } else if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(typeRef)) { // iterable
       // when type is both iterable and bean, we take it as iterable in row-format
-      Field f =
-          inferField(
-              DataTypes.ARRAY_ITEM_NAME,
-              TypeUtils.getElementType(typeRef),
-              seenTypeSet,
-              customTypes);
+      Field f = inferField(DataTypes.ARRAY_ITEM_NAME, TypeUtils.getElementType(typeRef), ctx);
       return DataTypes.arrayField(name, f);
     } else if (TypeUtils.MAP_TYPE.isSupertypeOf(typeRef)) {
       Tuple2<TypeRef<?>, TypeRef<?>> kvType = TypeUtils.getMapKeyValueType(typeRef);
-      Field keyField = inferField(MapVector.KEY_NAME, kvType.f0, seenTypeSet, customTypes);
+      Field keyField = inferField(MapVector.KEY_NAME, kvType.f0, ctx);
       // Map's keys must be non-nullable
       FieldType keyFieldType =
           new FieldType(
               false, keyField.getType(), keyField.getDictionary(), keyField.getMetadata());
       keyField = DataTypes.field(keyField.getName(), keyFieldType, keyField.getChildren());
-      Field valueField = inferField(MapVector.VALUE_NAME, kvType.f1, seenTypeSet, customTypes);
+      Field valueField = inferField(MapVector.VALUE_NAME, kvType.f1, ctx);
       return DataTypes.mapField(name, keyField, valueField);
-    } else if (TypeUtils.isBean(rawType, customTypes)) { // bean field
-      if (seenTypeSet.contains(rawType)) {
-        String msg =
-            String.format(
-                "circular references in bean class is not allowed, but got " + "%s in %s",
-                rawType, seenTypeSet);
-        throw new UnsupportedOperationException(msg);
-      }
+    } else if (TypeUtils.isBean(rawType, ctx)) { // bean field
+      ctx.checkNoCycle(rawType);
       List<Field> fields =
           Descriptor.getDescriptors(rawType).stream()
               .map(
                   descriptor -> {
-                    LinkedHashSet<Class<?>> newSeenTypeSet = new LinkedHashSet<>(seenTypeSet);
-                    newSeenTypeSet.add(rawType);
                     String n = StringUtils.lowerCamelToLowerUnderscore(descriptor.getName());
-                    return inferField(n, descriptor.getTypeRef(), newSeenTypeSet, customTypes);
+                    TypeResolutionContext newCtx = ctx.appendTypePath(rawType);
+                    TypeRef<?> fieldType = descriptor.getTypeRef();
+                    Class<?> rawFieldType = getRawType(fieldType);
+                    if (rawType.isInterface() && rawFieldType.isInterface()) {
+                      newCtx = newCtx.withSynthesizedBeanType(rawFieldType);
+                    }
+                    return inferField(n, fieldType, newCtx);
                   })
               .collect(Collectors.toList());
       return DataTypes.structField(name, true, fields);
     } else {
       throw new UnsupportedOperationException(
           String.format(
-              "Unsupported type %s for field %s, seen type set is %s", typeRef, name, seenTypeSet));
+              "Unsupported type %s for field %s, seen type set is %s",
+              typeRef, name, ctx.getWalkedTypePath()));
     }
   }
 
@@ -281,13 +269,5 @@ public class TypeInference {
   public static <E, C extends Collection<E>> void registerCustomCollectionFactory(
       Class<?> iterableType, Class<E> elementType, CustomCollectionFactory<E, C> factory) {
     CustomTypeEncoderRegistry.registerCustomCollection(iterableType, elementType, factory);
-  }
-
-  private static Class<?> enclosingType(LinkedHashSet<Class<?>> newTypePath) {
-    Class<?> result = Object.class;
-    for (Class<?> type : newTypePath) {
-      result = type;
-    }
-    return result;
   }
 }

--- a/java/fury-format/src/test/java/org/apache/fury/format/encoder/ImplementInterfaceTest.java
+++ b/java/fury-format/src/test/java/org/apache/fury/format/encoder/ImplementInterfaceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.format.encoder;
+
+import lombok.Data;
+import org.apache.fury.annotation.FuryField;
+import org.apache.fury.format.row.binary.BinaryRow;
+import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.memory.MemoryUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ImplementInterfaceTest {
+
+  public interface InterfaceType {
+    int getF1();
+
+    String getF2();
+
+    NestedType getNested();
+
+    PoisonPill getPoison();
+  }
+
+  public interface NestedType {
+    @FuryField(nullable = false)
+    String getF3();
+  }
+
+  public static class PoisonPill {}
+
+  @Data
+  static class ImplementInterface implements InterfaceType {
+    public int f1;
+    public String f2;
+    public NestedType nested;
+    public PoisonPill poison = new PoisonPill();
+
+    public ImplementInterface(final int f1, final String f2) {
+      this.f1 = f1;
+      this.f2 = f2;
+    }
+  }
+
+  @Data
+  static class ImplementNestedType implements NestedType {
+    public String f3;
+
+    public ImplementNestedType(final String f3) {
+      this.f3 = f3;
+    }
+  }
+
+  static {
+    Encoders.registerCustomCodec(PoisonPill.class, new PoisonPillCodec());
+  }
+
+  @Test
+  public void testInterfaceTypes() {
+    final InterfaceType bean1 = new ImplementInterface(42, "42");
+    final RowEncoder<InterfaceType> encoder = Encoders.bean(InterfaceType.class);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final InterfaceType deserializedBean = encoder.fromRow(row);
+    assertEquals(bean1, deserializedBean);
+  }
+
+  @Test
+  public void testNullValue() {
+    final InterfaceType bean1 = new ImplementInterface(42, null);
+    final RowEncoder<InterfaceType> encoder = Encoders.bean(InterfaceType.class);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final InterfaceType deserializedBean = encoder.fromRow(row);
+    assertEquals(deserializedBean, bean1);
+  }
+
+  @Test
+  public void testNestedValue() {
+    final ImplementInterface bean1 = new ImplementInterface(42, "42");
+    bean1.nested = new ImplementNestedType("f3");
+    final RowEncoder<InterfaceType> encoder = Encoders.bean(InterfaceType.class);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final InterfaceType deserializedBean = encoder.fromRow(row);
+    assertEquals(bean1, deserializedBean);
+    Assert.assertEquals(bean1.nested.getF3(), deserializedBean.getNested().getF3());
+  }
+
+  private void assertEquals(final InterfaceType bean1, final InterfaceType deserializedBean) {
+    Assert.assertNotSame(deserializedBean.getClass(), bean1.getClass());
+    Assert.assertEquals(deserializedBean.getF1(), bean1.getF1());
+    Assert.assertEquals(deserializedBean.getF2(), bean1.getF2());
+  }
+
+  static class PoisonPillCodec implements CustomCodec.ByteArrayCodec<PoisonPill> {
+    @Override
+    public byte[] encode(final PoisonPill value) {
+      return new byte[0];
+    }
+
+    @Override
+    public PoisonPill decode(final byte[] value) {
+      throw new AssertionError();
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

You can now call `Encoders.registerLazyBeanInterface` and Fury will generate a bean implementation type for you.
This should allow easy integration with Immutables library for example - I will be testing that over the coming days.

## Related issues

Fixes #2223

## Does this PR introduce any user-facing change?

New api to register interface types. Since this was not implemented before, there should be no breaking change.

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

