### PR TITLE
chore(java): switch to using java --release option

### DIFF
--- a/java/fury-core/pom.xml
+++ b/java/fury-core/pom.xml
@@ -47,8 +47,6 @@
   </description>
 
   <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
     <fury.java.rootdir>${basedir}/..</fury.java.rootdir>
   </properties>
 

--- a/java/fury-extensions/pom.xml
+++ b/java/fury-extensions/pom.xml
@@ -48,8 +48,6 @@
 
   <properties>
     <zstd.version>1.5.6-9</zstd.version>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
     <fury.java.rootdir>${basedir}/..</fury.java.rootdir>
   </properties>
 

--- a/java/fury-format/pom.xml
+++ b/java/fury-format/pom.xml
@@ -47,8 +47,6 @@
   </description>
 
   <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
     <arrow.version>15.0.0</arrow.version>
     <jackson-bom.version>2.16.0</jackson-bom.version>
     <fury.java.rootdir>${basedir}/..</fury.java.rootdir>

--- a/java/fury-test-core/pom.xml
+++ b/java/fury-test-core/pom.xml
@@ -32,8 +32,6 @@
   <artifactId>fury-test-core</artifactId>
 
   <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <fury.java.rootdir>${basedir}/..</fury.java.rootdir>

--- a/java/fury-testsuite/pom.xml
+++ b/java/fury-testsuite/pom.xml
@@ -32,8 +32,6 @@
   <artifactId>fury-testsuite</artifactId>
 
   <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <fury.java.rootdir>${basedir}/..</fury.java.rootdir>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -78,8 +78,7 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>1.8</maven.compiler.release>
     <guava.version>32.1.2-jre</guava.version>
     <janino.version>3.1.12</janino.version>
     <commons_codec.version>1.13</commons_codec.version>


### PR DESCRIPTION

## What does this PR do?

since maven-compiler-plugin 3.13, you can use the maven compiler release support even on java 8
the release setting will set source and target level together, and also filter api to those supported by the given release

parent sets the default for submodules so no need to set it everywhere
