### PR TITLE
feat(java): row format supports Record types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
         run: ./ci/run_ci.sh install_pyfury
       - name: Run CI with Maven
         run: ./ci/run_ci.sh java${{ matrix.java-version }}
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: surefire-reports-${{ matrix.java-version }}
+          path: "**/target/surefire-reports/**"
+
   openj9:
     name: Openj9 Java CI
     runs-on: ubuntu-latest

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -146,10 +146,11 @@ integration_tests() {
 
 jdk17_plus_tests() {
   java -version
+  export JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
   echo "Executing fury java tests"
   cd "$ROOT/java"
   set +e
-  mvn -T10 --batch-mode --no-transfer-progress test install -pl '!fury-format,!fury-testsuite'
+  mvn -T10 --batch-mode --no-transfer-progress install
   testcode=$?
   if [[ $testcode -ne 0 ]]; then
     exit $testcode

--- a/integration_tests/latest_jdk_tests/pom.xml
+++ b/integration_tests/latest_jdk_tests/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.fury</groupId>
+      <artifactId>fury-format</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fury</groupId>
       <artifactId>fury-test-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/integration_tests/latest_jdk_tests/src/test/java/org/apache/fury/integration_tests/RecordRowTest.java
+++ b/integration_tests/latest_jdk_tests/src/test/java/org/apache/fury/integration_tests/RecordRowTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.fury.integration_tests;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import org.apache.fury.format.encoder.Encoders;
 import org.apache.fury.format.encoder.RowEncoder;
 import org.apache.fury.format.row.binary.BinaryRow;
@@ -29,14 +31,15 @@ import org.testng.annotations.Test;
 
 public class RecordRowTest {
 
-  public record TestRecord(int f1, String f2) {}
+  public record TestRecord(Instant f1, String f2, LocalDate f3) {}
 
   // Intentionally mis-ordered to ensure record component order is different from sorted field order
   public record OuterTestRecord(long f2, long f1, TestRecord f3) {}
 
   @Test
   public void testRecord() {
-    final TestRecord bean = new TestRecord(42, "Luna");
+    final TestRecord bean =
+        new TestRecord(Instant.ofEpochMilli(42), "Luna", LocalDate.ofEpochDay(1234));
     final RowEncoder<TestRecord> encoder = Encoders.bean(TestRecord.class);
     final BinaryRow row = encoder.toRow(bean);
     final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
@@ -47,7 +50,8 @@ public class RecordRowTest {
 
   @Test
   public void testNestedRecord() {
-    final TestRecord nested = new TestRecord(43, "Mars");
+    final TestRecord nested =
+        new TestRecord(Instant.ofEpochMilli(43), "Mars", LocalDate.ofEpochDay(5678));
     final OuterTestRecord bean = new OuterTestRecord(12, 34, nested);
     final RowEncoder<OuterTestRecord> encoder = Encoders.bean(OuterTestRecord.class);
     final BinaryRow row = encoder.toRow(bean);

--- a/integration_tests/latest_jdk_tests/src/test/java/org/apache/fury/integration_tests/RecordRowTest.java
+++ b/integration_tests/latest_jdk_tests/src/test/java/org/apache/fury/integration_tests/RecordRowTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.integration_tests;
+
+import org.apache.fury.format.encoder.Encoders;
+import org.apache.fury.format.encoder.RowEncoder;
+import org.apache.fury.format.row.binary.BinaryRow;
+import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.memory.MemoryUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RecordRowTest {
+
+  public record TestRecord(int f1, String f2) {}
+
+  // Intentionally mis-ordered to ensure record component order is different from sorted field order
+  public record OuterTestRecord(long f2, long f1, TestRecord f3) {}
+
+  @Test
+  public void testRecord() {
+    final TestRecord bean = new TestRecord(42, "Luna");
+    final RowEncoder<TestRecord> encoder = Encoders.bean(TestRecord.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final TestRecord deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean, bean);
+  }
+
+  @Test
+  public void testNestedRecord() {
+    final TestRecord nested = new TestRecord(43, "Mars");
+    final OuterTestRecord bean = new OuterTestRecord(12, 34, nested);
+    final RowEncoder<OuterTestRecord> encoder = Encoders.bean(OuterTestRecord.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final OuterTestRecord deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean, bean);
+  }
+}

--- a/java/fury-core/src/main/java/org/apache/fury/type/TypeUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/TypeUtils.java
@@ -54,6 +54,7 @@ import org.apache.fury.reflect.TypeRef;
 import org.apache.fury.serializer.NonexistentClass;
 import org.apache.fury.util.Preconditions;
 import org.apache.fury.util.StringUtils;
+import org.apache.fury.util.record.RecordUtils;
 
 /** Type utils for common type inference and extraction. */
 @SuppressWarnings({"UnstableApiUsage", "unchecked"})
@@ -598,7 +599,7 @@ public class TypeUtils {
 
   public static boolean isBean(TypeRef<?> typeRef, TypeResolutionContext ctx) {
     Class<?> cls = getRawType(typeRef);
-    if (ctx.isSynthesizedBeanType(cls)) {
+    if (ctx.isSynthesizedBeanType(cls) || RecordUtils.isRecord(cls)) {
       return true;
     }
     if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/Encoders.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/Encoders.java
@@ -135,6 +135,7 @@ public class Encoders {
    *   <li>time related: java.sql.Date, java.sql.Timestamp, java.time.LocalDate, java.time.Instant
    *   <li>Optional and friends: OptionalInt, OptionalLong, OptionalDouble
    *   <li>collection types: only array and java.util.List currently, map support is in progress
+   *   <li>record types
    *   <li>nested java bean
    * </ul>
    */

--- a/java/fury-format/src/main/java/org/apache/fury/format/row/binary/BinaryUtils.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/row/binary/BinaryUtils.java
@@ -49,6 +49,10 @@ public class BinaryUtils {
       return "getDate";
     } else if (TypeUtils.TIMESTAMP_TYPE.equals(type)) {
       return "getTimestamp";
+    } else if (TypeUtils.INSTANT_TYPE.equals(type)) {
+      return "getInt64";
+    } else if (TypeUtils.LOCAL_DATE_TYPE.equals(type)) {
+      return "getInt32";
     } else if (TypeUtils.STRING_TYPE.equals(type)) {
       return "getString";
     } else if (isArray(type)) {
@@ -89,6 +93,10 @@ public class BinaryUtils {
       return TypeUtils.INT_TYPE;
     } else if (TypeUtils.TIMESTAMP_TYPE.equals(type)) {
       return TypeUtils.LONG_TYPE;
+    } else if (TypeUtils.INSTANT_TYPE.equals(type)) {
+      return TypeUtils.LONG_TYPE;
+    } else if (TypeUtils.LOCAL_DATE_TYPE.equals(type)) {
+      return TypeUtils.INT_TYPE;
     } else if (TypeUtils.STRING_TYPE.equals(type)) {
       return TypeUtils.STRING_TYPE;
     } else if (isArray(type)) {

--- a/java/fury-format/src/main/java/org/apache/fury/format/type/TypeInference.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/type/TypeInference.java
@@ -242,7 +242,7 @@ public class TypeInference {
                     TypeResolutionContext newCtx = ctx.appendTypePath(rawType);
                     TypeRef<?> fieldType = descriptor.getTypeRef();
                     Class<?> rawFieldType = getRawType(fieldType);
-                    if (rawType.isInterface() && rawFieldType.isInterface()) {
+                    if (rawFieldType.isInterface()) {
                       newCtx = newCtx.withSynthesizedBeanType(rawFieldType);
                     }
                     return inferField(n, fieldType, newCtx);


### PR DESCRIPTION

## What does this PR do?

Support Record types in row format

Treated as Bean types, except we have to use canonical constructor instead of unsafe field setting

Test only runs on Java 17+

## Does this PR introduce any user-facing change?

New type support in java row format

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
