### PR TITLE
fix(java): row encoder incorrectly interprets type parameters as cycles

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
@@ -656,6 +656,7 @@ public class Encoders {
         if (TypeUtils.isBean(typeRef)) {
           set.add(typeRef);
         }
+        findBeanToken(typeRef, set);
       } else {
         Tuple2<TypeRef<?>, TypeRef<?>> tuple2 = TypeUtils.getMapKeyValueType(typeRef);
         if (TypeUtils.isBean(tuple2.f0)) {

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/GenericTypeTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/GenericTypeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.format.encoder;
+
+import lombok.Data;
+import org.apache.fory.format.row.binary.BinaryRow;
+import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.memory.MemoryUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class GenericTypeTest {
+
+  @Data
+  public static class TypedId<T> {
+    int id;
+
+    public TypedId() {}
+  }
+
+  @Data
+  public static class TestEntity {
+    TypedId<TestEntity> id;
+
+    public TestEntity() {}
+  }
+
+  @Test
+  public void testRecursiveGenericType() {
+    final TestEntity bean = new TestEntity();
+    bean.id = new TypedId<>();
+    bean.id.id = 42;
+    final RowEncoder<TestEntity> encoder = Encoders.bean(TestEntity.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final TestEntity deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean, bean);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Given a typed-identifier type `class Id<T> { int id; }` and a `class T { Id<T> id; }`, Fury incorrectly reports a type cycle of T, but the Id type does not actually have any property of type T.
This is due to over-eager expansion of bean types in the type utils - all generic types are assumed to be used as property types, which is not always correct.
