### PR TITLE
chore(java): skip xlang tests when pyfory is not available

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -24,6 +24,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 echo "Root path: $ROOT, home path: $HOME"
 cd "$ROOT"
 
+export FORY_CI=true
 
 install_python() {
   wget -q https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.2-0-Linux-x86_64.sh -O Miniconda3.sh

--- a/java/fory-core/src/test/java/org/apache/fory/CrossLanguageTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/CrossLanguageTest.java
@@ -71,6 +71,7 @@ import org.apache.fory.type.Descriptor;
 import org.apache.fory.util.DateTimeUtils;
 import org.apache.fory.util.MurmurHash3;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** Tests in this class need fory python installed. */
@@ -79,6 +80,11 @@ public class CrossLanguageTest extends ForyTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(CrossLanguageTest.class);
   private static final String PYTHON_MODULE = "pyfory.tests.test_cross_language";
   private static final String PYTHON_EXECUTABLE = "python";
+
+  @BeforeClass
+  public void isPyforyInstalled() {
+    TestUtils.verifyPyforyInstalled();
+  }
 
   /**
    * Execute an external command.

--- a/java/fory-format/src/test/java/org/apache/fory/format/CrossLanguageTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/CrossLanguageTest.java
@@ -69,6 +69,7 @@ import org.apache.fory.memory.MemoryUtils;
 import org.apache.fory.serializer.BufferObject;
 import org.apache.fory.test.TestUtils;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** Tests in this class need fory python installed. */
@@ -77,6 +78,11 @@ public class CrossLanguageTest {
   private static final Logger LOG = LoggerFactory.getLogger(CrossLanguageTest.class);
   private static final String PYTHON_MODULE = "pyfory.tests.test_cross_language";
   private static final String PYTHON_EXECUTABLE = "python";
+
+  @BeforeClass
+  public void isPythonInstalled() {
+    TestUtils.verifyPyforyInstalled();
+  }
 
   @Data
   public static class A {

--- a/java/fory-test-core/src/main/java/org/apache/fory/test/TestUtils.java
+++ b/java/fory-test-core/src/main/java/org/apache/fory/test/TestUtils.java
@@ -21,10 +21,13 @@ package org.apache.fory.test;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import org.testng.SkipException;
 
 public class TestUtils {
   public static String random(int size, int rand) {
@@ -72,6 +75,22 @@ public class TestUtils {
       }
     } catch (Exception e) {
       throw new RuntimeException("Error executing command " + String.join(" ", command), e);
+    }
+  }
+
+  public static void verifyPyforyInstalled() {
+    // Don't skip in CI, fail if something goes wrong instead
+    if (System.getenv("FORY_CI") != null) {
+      return;
+    }
+    if (executeCommand(
+        Arrays.asList(
+            "python",
+            "-c",
+            "import importlib, sys; sys.exit(0 if importlib.util.find_spec(\"pyfory\") is None else 1)"),
+        10,
+        Collections.emptyMap())) {
+      throw new SkipException("pyfory not installed");
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

right now a Java dev has to contend with failing tests that require Python
by skipping the xlang tests when pyfory is not available, a Java developer can build without needing to set up pyfory
