### PR TITLE
fix(scala): Ensure singleton classes are initialized before reading

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/serializer/scala/SingletonObjectSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/scala/SingletonObjectSerializer.java
@@ -40,6 +40,11 @@ public class SingletonObjectSerializer extends Serializer {
   public SingletonObjectSerializer(Fory fory, Class type) {
     super(fory, type);
     try {
+      Class.forName(type.getName(), true, type.getClassLoader());
+    } catch (final ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    try {
       field = type.getDeclaredField("MODULE$");
     } catch (NoSuchFieldException e) {
       throw new RuntimeException(type + " doesn't have `MODULE$` field", e);


### PR DESCRIPTION
<!--
**Thanks for contributing to Fory.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Fory has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR fixes an issue in Scala. 

Since Scala object's are lazy, the singleton instance doesn't exist or it does exist, but its value is `null` so when `SingletonObjectSerializer.read` is called we get null. This PR resolves the issue by ensuring that the object is initialized before deserialization. 

## Related issues

https://github.com/apache/fury/issues/2249

I verified that this change resolves the issue for the repro code in the "Anything else?" section of https://github.com/apache/fury/issues/2249


#### Before

```
[info] running Main 
2025-05-29 10:45:26 WARN  FuryBuilder:427 [sbt-bg-threads-5] - Class registration isn't forced, unknown classes can be deserialized. If the environment isn't secure, please enable class registration by `FuryBuilder#requireClassRegistration(true)` or configure ClassChecker by `ClassResolver#setClassChecker`
2025-05-29 10:45:26 INFO  Fury:159 [sbt-bg-threads-5] - Created new fury org.apache.fury.Fury@4d820972
2025-05-29 10:45:27 INFO  CompileUnit:55 [sbt-bg-threads-5] - Generate code for Main_Transportation_DefaultFuryRefCodec_0 took 5 ms.
2025-05-29 10:45:27 INFO  JaninoUtils:121 [sbt-bg-threads-5] - Compile [Main_Transportation_DefaultFuryRefCodec_0] take 40 ms
Default(10,null)
[success] Total time: 0 s, completed May 29, 2025, 10:45:27 AM
```

#### After

```
[info] running Main 
2025-05-29 10:46:06 WARN  FuryBuilder:427 [sbt-bg-threads-7] - Class registration isn't forced, unknown classes can be deserialized. If the environment isn't secure, please enable class registration by `FuryBuilder#requireClassRegistration(true)` or configure ClassChecker by `ClassResolver#setClassChecker`
2025-05-29 10:46:06 INFO  Fury:159 [sbt-bg-threads-7] - Created new fury org.apache.fury.Fury@499a5e1b
2025-05-29 10:46:06 INFO  CompileUnit:55 [sbt-bg-threads-7] - Generate code for Main_Transportation_DefaultFuryRefCodec_0 took 4 ms.
2025-05-29 10:46:06 INFO  JaninoUtils:121 [sbt-bg-threads-7] - Compile [Main_Transportation_DefaultFuryRefCodec_0] take 42 ms
Default(10,Car)
[success] Total time: 0 s, completed May 29, 2025, 10:46:06 AM
```

## Alternatives 

The proposed change in https://github.com/apache/fury/issues/2249#issuecomment-2917722732 worked well for our older JDK version, but failed on newer versions since the methods were [removed](https://bugs.openjdk.org/browse/JDK-8316160?subTaskView=unresolved). 

```
Error:  /home/runner/work/fury/fury/java/fory-core/src/main/java/org/apache/fory/serializer/scala/SingletonObjectSerializer.java:[42,24] cannot find symbol
Error:    symbol:   method shouldBeInitialized(java.lang.Class)
Error:    location: variable UNSAFE of type sun.misc.Unsafe
```

Instead we took inspiration from https://github.com/eclipse-serializer/serializer/pull/109/files 


