### PR TITLE
chore(java): Use `crossLanguage` instead of `language` in Fory

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassInfo.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassInfo.java
@@ -83,7 +83,7 @@ public class ClassInfo {
     this.serializer = serializer;
     needToWriteClassDef = serializer != null && classResolver.needToWriteClassDef(serializer);
     MetaStringResolver metaStringResolver = classResolver.getMetaStringResolver();
-    if (cls != null && classResolver.getFory().getLanguage() != Language.JAVA) {
+    if (cls != null && classResolver.getFory().isCrossLanguage()) {
       this.fullNameBytes =
           metaStringResolver.getOrCreateMetaStringBytes(
               GENERIC_ENCODER.encode(cls.getName(), Encoding.UTF_8));

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassInfo.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassInfo.java
@@ -24,7 +24,6 @@ import static org.apache.fory.meta.Encoders.PACKAGE_DECODER;
 import static org.apache.fory.meta.Encoders.TYPE_NAME_DECODER;
 
 import org.apache.fory.collection.Tuple2;
-import org.apache.fory.config.Language;
 import org.apache.fory.meta.ClassDef;
 import org.apache.fory.meta.Encoders;
 import org.apache.fory.meta.MetaString.Encoding;

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -738,7 +738,7 @@ public class ClassResolver implements TypeResolver {
    */
   public void registerSerializer(Class<?> type, Serializer<?> serializer) {
     if (!extRegistry.registeredClassIdMap.containsKey(type)
-        && fory.getLanguage() == Language.JAVA) {
+        && !fory.isCrossLanguage()) {
       register(type);
     }
     addSerializer(type, serializer);
@@ -997,7 +997,7 @@ public class ClassResolver implements TypeResolver {
         if (requireJavaSerialization(cls) || useReplaceResolveSerializer(cls)) {
           return CollectionSerializers.JDKCompatibleCollectionSerializer.class;
         }
-        if (fory.getLanguage() == Language.JAVA) {
+        if (!fory.isCrossLanguage()) {
           return CollectionSerializers.DefaultJavaCollectionSerializer.class;
         } else {
           return CollectionSerializer.class;
@@ -1011,13 +1011,13 @@ public class ClassResolver implements TypeResolver {
         if (requireJavaSerialization(cls) || useReplaceResolveSerializer(cls)) {
           return MapSerializers.JDKCompatibleMapSerializer.class;
         }
-        if (fory.getLanguage() == Language.JAVA) {
+        if (!fory.isCrossLanguage()) {
           return MapSerializers.DefaultJavaMapSerializer.class;
         } else {
           return MapSerializer.class;
         }
       }
-      if (fory.getLanguage() != Language.JAVA) {
+      if (fory.isCrossLanguage()) {
         LOG.warn("Class {} isn't supported for cross-language serialization.", cls);
       }
       if (useReplaceResolveSerializer(cls)) {

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -737,8 +737,7 @@ public class ClassResolver implements TypeResolver {
    * @param serializer serializer for object of {@code type}
    */
   public void registerSerializer(Class<?> type, Serializer<?> serializer) {
-    if (!extRegistry.registeredClassIdMap.containsKey(type)
-        && !fory.isCrossLanguage()) {
+    if (!extRegistry.registeredClassIdMap.containsKey(type) && !fory.isCrossLanguage()) {
       register(type);
     }
     addSerializer(type, serializer);

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/Serializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/Serializer.java
@@ -73,7 +73,7 @@ public abstract class Serializer<T> {
   public Serializer(Fory fory, Class<T> type) {
     this.fory = fory;
     this.type = type;
-    this.isJava = fory.getLanguage() == Language.JAVA;
+    this.isJava = !fory.isCrossLanguage();
     if (fory.trackingRef()) {
       needToWriteRef = !TypeUtils.isBoxed(TypeUtils.wrap(type)) || !fory.isBasicTypesRefIgnored();
     } else {
@@ -86,7 +86,7 @@ public abstract class Serializer<T> {
   public Serializer(Fory fory, Class<T> type, boolean immutable) {
     this.fory = fory;
     this.type = type;
-    this.isJava = fory.getLanguage() == Language.JAVA;
+    this.isJava = !fory.isCrossLanguage();
     if (fory.trackingRef()) {
       needToWriteRef = !TypeUtils.isBoxed(TypeUtils.wrap(type)) || !fory.isBasicTypesRefIgnored();
     } else {
@@ -99,7 +99,7 @@ public abstract class Serializer<T> {
   public Serializer(Fory fory, Class<T> type, boolean needToWriteRef, boolean immutable) {
     this.fory = fory;
     this.type = type;
-    this.isJava = fory.getLanguage() == Language.JAVA;
+    this.isJava = !fory.isCrossLanguage();
     this.needToWriteRef = needToWriteRef;
     this.needToCopyRef = fory.copyTrackingRef() && !immutable;
     this.immutable = immutable;

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/Serializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/Serializer.java
@@ -21,7 +21,6 @@ package org.apache.fory.serializer;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.fory.Fory;
-import org.apache.fory.config.Language;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.type.TypeUtils;
 

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
@@ -694,8 +694,8 @@ public class CollectionSerializers {
     public DefaultJavaCollectionSerializer(Fory fory, Class<T> cls) {
       super(fory, cls, false);
       Preconditions.checkArgument(
-          fory.getLanguage() == Language.JAVA,
-          "Python default collection serializer should use " + CollectionSerializer.class);
+          !fory.isCrossLanguage(),
+          "Fory cross-language default collection serializer should use " + CollectionSerializer.class);
       fory.getClassResolver().setSerializer(cls, this);
       Class<? extends Serializer> serializerClass =
           fory.getClassResolver()

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.fory.Fory;
-import org.apache.fory.config.Language;
 import org.apache.fory.exception.ForyException;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.memory.Platform;
@@ -695,7 +694,8 @@ public class CollectionSerializers {
       super(fory, cls, false);
       Preconditions.checkArgument(
           !fory.isCrossLanguage(),
-          "Fory cross-language default collection serializer should use " + CollectionSerializer.class);
+          "Fory cross-language default collection serializer should use "
+              + CollectionSerializer.class);
       fory.getClassResolver().setSerializer(cls, this);
       Class<? extends Serializer> serializerClass =
           fory.getClassResolver()

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/MapSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/MapSerializers.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.fory.Fory;
 import org.apache.fory.collection.LazyMap;
-import org.apache.fory.config.Language;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.memory.Platform;
 import org.apache.fory.reflect.ReflectionUtils;

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/MapSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/MapSerializers.java
@@ -384,8 +384,8 @@ public class MapSerializers {
     public DefaultJavaMapSerializer(Fory fory, Class<T> cls) {
       super(fory, cls, false);
       Preconditions.checkArgument(
-          fory.getLanguage() == Language.JAVA,
-          "Python default map serializer should use " + MapSerializer.class);
+          !fory.isCrossLanguage(),
+          "Fory cross-language default map serializer should use " + MapSerializer.class);
       fory.getClassResolver().setSerializer(cls, this);
       Class<? extends Serializer> serializerClass =
           fory.getClassResolver()

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/SubListSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/SubListSerializers.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.apache.fory.Fory;
-import org.apache.fory.config.Language;
 import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.memory.MemoryBuffer;

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/SubListSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/SubListSerializers.java
@@ -70,7 +70,7 @@ public class SubListSerializers {
     // ImmutableCollectionSerializers
     for (Class<?> cls :
         new Class[] {SubListClass, RandomAccessSubListClass, ArrayListSubListClass}) {
-      if (fory.trackingRef() && preserveView && fory.getConfig().getLanguage() == Language.JAVA) {
+      if (fory.trackingRef() && preserveView && !fory.isCrossLanguage()) {
         classResolver.registerSerializer(cls, new SubListViewSerializer(fory, cls));
       } else {
         classResolver.registerSerializer(cls, new SubListSerializer(fory, (Class<List>) cls));
@@ -84,7 +84,7 @@ public class SubListSerializers {
 
     public SubListViewSerializer(Fory fory, Class cls) {
       super(fory, Stub.class.isAssignableFrom(cls) ? (Class<List>) ArrayListSubListClass : cls);
-      assert fory.getLanguage() == Language.JAVA;
+      assert !fory.isCrossLanguage();
     }
 
     @Override

--- a/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
@@ -190,7 +190,7 @@ public class ForyTest extends ForyTestBase {
     assertEquals(Short.MAX_VALUE, serDeCheckIndex(fory1, fory2, buffer, Short.MAX_VALUE));
     assertEquals("str", serDeCheckIndex(fory1, fory2, buffer, "str"));
     assertEquals("str", serDeCheckIndex(fory1, fory2, buffer, new StringBuilder("str")).toString());
-    if (fory1.getLanguage() != Language.JAVA) {
+    if (fory1.isCrossLanguage()) {
       fory1.register(EnumSerializerTest.EnumFoo.class);
       fory2.register(EnumSerializerTest.EnumFoo.class);
       fory1.register(EnumSerializerTest.EnumSubClass.class);

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/EnumSerializerTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/EnumSerializerTest.java
@@ -64,7 +64,7 @@ public class EnumSerializerTest extends ForyTestBase {
             .requireClassRegistration(false);
     Fory fory1 = builder.build();
     Fory fory2 = builder.build();
-    if (fory1.getLanguage() != Language.JAVA) {
+    if (fory1.isCrossLanguage()) {
       fory1.register(EnumSerializerTest.EnumFoo.class);
       fory2.register(EnumSerializerTest.EnumFoo.class);
       fory1.register(EnumSerializerTest.EnumSubClass.class);

--- a/java/fory-format/src/main/java/org/apache/fory/format/vectorized/ArrowSerializers.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/vectorized/ArrowSerializers.java
@@ -31,7 +31,6 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.fory.Fory;
-import org.apache.fory.config.Language;
 import org.apache.fory.io.MemoryBufferReadableChannel;
 import org.apache.fory.io.MemoryBufferWritableChannel;
 import org.apache.fory.io.MockWritableChannel;

--- a/java/fory-format/src/main/java/org/apache/fory/format/vectorized/ArrowSerializers.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/vectorized/ArrowSerializers.java
@@ -167,7 +167,7 @@ public class ArrowSerializers {
   }
 
   public static void registerSerializers(Fory fory) {
-    if (fory.getLanguage() != Language.JAVA) {
+    if (fory.isCrossLanguage()) {
       fory.register(ArrowTable.class, Types.ARROW_TABLE);
       fory.register(VectorSchemaRoot.class, Types.ARROW_RECORD_BATCH);
     }


### PR DESCRIPTION
## What does this PR do?
The Fory class fields `language` and `crossLanguage` are redundant and can be quickly determined using `crossLanguage` without the need for `language`.