### PR TITLE
fix(java): descriptors for beans should not include static methods

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
@@ -462,7 +462,9 @@ public class Descriptor {
     }
     if (clazz.isInterface()) {
       for (Method method : clazz.getMethods()) {
-        if (method.getParameterCount() == 0 && method.getReturnType() != void.class) {
+        if (method.getParameterCount() == 0
+            && method.getReturnType() != void.class
+            && !Modifier.isStatic(method.getModifiers())) {
           descriptorMap.put(method, new Descriptor(method));
         }
       }

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
@@ -37,6 +37,10 @@ public class ImplementInterfaceTest {
     NestedType getNested();
 
     PoisonPill getPoison();
+
+    static PoisonPill builder() {
+      return new PoisonPill();
+    }
   }
 
   public interface NestedType {


### PR DESCRIPTION
## What does this PR do?

Bean interface method descriptor discovery incorrectly includes static methods like `static Builder builder()`