### PR TITLE
chore(java): gitignore test-output from integration_tests as well as java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ benchmark/target
 **/target/**/**
 java/**/.code/
 java/**/dependency-reduced-pom.xml
-java/**/test-output
+**/test-output
 **/pom.xml.versionsBackup
 **/.code/
 **/*.iml


### PR DESCRIPTION
right now, running integration tests makes your checkout not clean